### PR TITLE
Fixed issues with enabling/disabling tracking and MT scenarios.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -103,6 +103,11 @@ Here is a quick example on how to use this plugin. For more details, please look
   
   # undelete post
   post.undo! @user
+  
+  # disable tracking for comments within a block
+  Comment.disable_tracking do
+    comment.update_attributes(:title => "Test 3")
+  end
 
 == Contributing to mongoid-history
  

--- a/lib/mongoid-history.rb
+++ b/lib/mongoid-history.rb
@@ -4,6 +4,6 @@ require File.expand_path(File.dirname(__FILE__) + '/mongoid/history')
 require File.expand_path(File.dirname(__FILE__) + '/mongoid/history/tracker')
 require File.expand_path(File.dirname(__FILE__) + '/mongoid/history/trackable')
 
-Mongoid::History.modifer_class_name = "User"
+Mongoid::History.modifier_class_name = "User"
 Mongoid::History.trackable_classes = []
 Mongoid::History.trackable_class_options = {}

--- a/lib/mongoid/history.rb
+++ b/lib/mongoid/history.rb
@@ -3,7 +3,7 @@ module Mongoid
     mattr_accessor :tracker_class_name
     mattr_accessor :trackable_classes
     mattr_accessor :trackable_class_options
-    mattr_accessor :modifer_class_name
+    mattr_accessor :modifier_class_name
     
     def self.tracker_class
       @tracker_class ||= tracker_class_name.to_s.classify.constantize

--- a/lib/mongoid/history/tracker.rb
+++ b/lib/mongoid/history/tracker.rb
@@ -12,7 +12,7 @@ module Mongoid::History
       field       :version,                 :type => Integer
       field       :action,                  :type => String
       field       :scope,                   :type => String
-      referenced_in :modifier,              :class_name => Mongoid::History.modifer_class_name
+      referenced_in :modifier,              :class_name => Mongoid::History.modifier_class_name
 
       Mongoid::History.tracker_class_name = self.name.tableize.singularize.to_sym
     end

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -72,5 +72,42 @@ describe Mongoid::History::Trackable do
     it "should define #history_trackable_options" do
       MyModel.history_trackable_options.should == @expected_option
     end
+
+    context "track_history" do
+    
+      it "should be enabled on the current thread" do
+        MyModel.new.track_history?.should == true
+      end
+      
+      it "should be disabled within disable_tracking" do
+        MyModel.disable_tracking do
+          MyModel.new.track_history?.should == false
+        end
+      end
+      
+      it "should be rescued if an exception occurs" do
+        begin
+          MyModel.disable_tracking do
+            raise "exception"
+          end
+        rescue
+        end
+        MyModel.new.track_history?.should == true
+      end
+      
+      it "should be disabled only for the class that calls disable_tracking" do
+        class MyModel2
+          include Mongoid::Document
+          include Mongoid::History::Trackable
+          track_history
+        end
+        
+        MyModel.disable_tracking do
+          MyModel2.new.track_history?.should == true
+        end      
+      end
+    
+    end
+    
   end
 end


### PR DESCRIPTION
- bug: tracking doesn't work in a multithreaded scenario (!! of a nil returns false and models are created on another thread failing to set the tracking option)
- extended disable_tracking to be per-model rather than global
- bug: an exception raised within the disable block permanently disables tracking
- fixed spelling of modifier
