### PR TITLE
Trying to solve issue #8

### DIFF
--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -115,7 +115,7 @@ module Mongoid::History
           end
         else
           options_or_version = options_or_version.to_a if options_or_version.is_a?(Range)
-          version = options_or_version || self.attributes[history_trackable_options[:version_field]]
+          version = options_or_version || self.attributes[history_trackable_options[:version_field]] || self.attributes[history_trackable_options[:version_field].to_s]
           version = [ version ].flatten
           versions = history_tracks.where(:version.in => version)
         end


### PR DESCRIPTION
when a version is not specified, add .to_s when it tries to get the current version, because in some system the attributes hash uses strings and in another ones uses symbols
