### PR TITLE
Fix issue when tracking boolean fields

### DIFF
--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -220,8 +220,8 @@ module Mongoid::History
         modified = {}
         changes.each_pair do |k, v|
           o, m = v
-          original[k] = o if o
-          modified[k] = m if m
+          original[k] = o unless o.nil?
+          modified[k] = m unless m.nil?
         end
 
         return original.easy_diff modified


### PR DESCRIPTION
When updating a class with Boolean field, it will now create a valid version with modified attribute set even if field's value is "false".
