### PR TITLE
get rid of trackable_classes array

### DIFF
--- a/lib/mongoid-history.rb
+++ b/lib/mongoid-history.rb
@@ -5,5 +5,4 @@ require File.expand_path(File.dirname(__FILE__) + '/mongoid/history/tracker')
 require File.expand_path(File.dirname(__FILE__) + '/mongoid/history/trackable')
 
 Mongoid::History.modifier_class_name = "User"
-Mongoid::History.trackable_classes = []
 Mongoid::History.trackable_class_options = {}

--- a/lib/mongoid/history.rb
+++ b/lib/mongoid/history.rb
@@ -1,7 +1,6 @@
 module Mongoid
   module History
     mattr_accessor :tracker_class_name
-    mattr_accessor :trackable_classes
     mattr_accessor :trackable_class_options
     mattr_accessor :modifier_class_name
 

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -46,8 +46,6 @@ module Mongoid::History
         before_create :track_create if options[:track_create]
         before_destroy :track_destroy if options[:track_destroy]
 
-        Mongoid::History.trackable_classes ||= []
-        Mongoid::History.trackable_classes << self
         Mongoid::History.trackable_class_options ||= {}
         Mongoid::History.trackable_class_options[model_name] = options
       end


### PR DESCRIPTION
Not sure if other people find this (would be very interesting to know), but at least for us this code causes our rails process to grow in memory as classes are reloaded (e.g. in development mode). Given `trackable_classes` doesn't seem to be used anywhere, maybe simpler just to remove it?
