### PR TITLE
get rid of trackable_classes array (attempt 2)

### DIFF
--- a/lib/mongoid-history.rb
+++ b/lib/mongoid-history.rb
@@ -6,6 +6,5 @@ require File.expand_path(File.dirname(__FILE__) + '/mongoid/history/trackable')
 require File.expand_path(File.dirname(__FILE__) + '/mongoid/history/sweeper')
 
 Mongoid::History.modifier_class_name = "User"
-Mongoid::History.trackable_classes = []
 Mongoid::History.trackable_class_options = {}
 Mongoid::History.current_user_method ||= :current_user

--- a/lib/mongoid/history.rb
+++ b/lib/mongoid/history.rb
@@ -1,7 +1,6 @@
 module Mongoid
   module History
     mattr_accessor :tracker_class_name
-    mattr_accessor :trackable_classes
     mattr_accessor :trackable_class_options
     mattr_accessor :modifier_class_name
     mattr_accessor :current_user_method

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -46,8 +46,6 @@ module Mongoid::History
         before_create :track_create if options[:track_create]
         before_destroy :track_destroy if options[:track_destroy]
 
-        Mongoid::History.trackable_classes ||= []
-        Mongoid::History.trackable_classes << self
         Mongoid::History.trackable_class_options ||= {}
         Mongoid::History.trackable_class_options[model_name] = options
       end

--- a/spec/trackable_spec.rb
+++ b/spec/trackable_spec.rb
@@ -9,18 +9,11 @@ describe Mongoid::History::Trackable do
   end
 
   after :each do
-    Mongoid::History.trackable_classes = nil
     Mongoid::History.trackable_class_options = nil
   end
 
   it "should have #track_history" do
     MyModel.should respond_to :track_history
-  end
-
-  it "should append trackable_classes ONLY when #track_history is called" do
-    Mongoid::History.trackable_classes.should be_blank
-    MyModel.track_history
-    Mongoid::History.trackable_classes.should == [MyModel]
   end
 
   it "should append trackable_class_options ONLY when #track_history is called" do
@@ -50,7 +43,6 @@ describe Mongoid::History::Trackable do
     end
 
     after :each do
-      Mongoid::History.trackable_classes = nil
       Mongoid::History.trackable_class_options = nil
     end
 


### PR DESCRIPTION
Not sure if other people find this (would be very interesting to know), but at least for us this code causes our rails process to grow in memory as classes are reloaded (e.g. in development mode). Given `trackable_classes` doesn't seem to be used anywhere, maybe simpler just to remove it?
