### PR TITLE
Fixing Trackable::association_hash nil meta value call.

### DIFF
--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -73,7 +73,7 @@ module Mongoid::History
       def history_tracks
         @history_tracks ||= Mongoid::History.tracker_class.where(:scope => history_trackable_options[:scope], :association_chain => association_hash)
       end
-      
+
       #  undo :from => 1, :to => 5
       #  undo 4
       #  undo :last => 10
@@ -140,7 +140,7 @@ module Mongoid::History
             node._parent == node.send(meta.key)
           end
 
-          inverse = node._parent.reflect_on_association(meta.inverse)
+          inverse = node._parent.reflect_on_association(meta.inverse) if meta
         end
 
         # if root node has no meta, and should use class name instead


### PR DESCRIPTION
Bug was exposed while trying to use 'accepts_nested_attributes_for' with
a child's _destroy flag set to true, and cascading callbacks turned on.
- If cascading_callbacks is not set then the call to
  'parent.update_attributes()' does not fire the child.destroy call.
- If accepts_nested_attributes_for is not set, then the call
  'parent.update_attributes()' does not attempt to write any nested child
  data.
- Finally, if we are not destroying the child, then things work fine.
  There are only issues if we issue the _destroy flag because the child's
  parent association is removed before mongoid-history has the
  opportunity to write a new history track to logging the destroy.
