### PR TITLE
Updating Trackable::association_hash to write relationship name.

### DIFF
--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -136,11 +136,9 @@ module Mongoid::History
         # get all reflections of embedded_in association metadata
         # and find the first association that matches _parent.
         if node._parent
-          meta = node.reflect_on_all_associations(:embedded_in).find do |meta|
-            node._parent == node.send(meta.key)
-          end
-
-          inverse = node._parent.reflect_on_association(meta.inverse) if meta
+          meta = node.relations.values.select do |relation|
+            relation.class_name == node._parent.class.to_s
+          end.first
         end
 
         # if root node has no meta, and should use class name instead


### PR DESCRIPTION
Currently there are cases (on destroy mainly) where an embedded document
writes it's class name to the association_hash name field, when it
fails to lookup the relationship meta information pertaining to it's
parent.

If you were to then call 'trackable_parent', or other methods that wall
up the association chain, the method would error because it would try to
traverse a relationship titled "Comment" instead of the correct value
"comments".

This fix makes it so a child document never fails to lookup the name of
the relationship that it's parent uses to refer to it. Thus class names
never get used in the association_chain name hash.
