### PR TITLE
Updating Trackable::association_hash to write through parent.

### DIFF
--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -134,9 +134,9 @@ module Mongoid::History
 
       def association_hash(node=self)
 
-        #We prefer to look up associations through the parent record because
-        #we're assured, through the object creation, it'll exsist. Whereas we're not guarenteed
-        #the child to parent (embedded_in, belongs_to) relation will be defined
+        # We prefer to look up associations through the parent record because
+        # we're assured, through the object creation, it'll exist. Whereas we're not guarenteed
+        # the child to parent (embedded_in, belongs_to) relation will be defined
         if node._parent
           meta = _parent.relations.values.select do |relation|
             relation.class_name == node.class.to_s

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -387,8 +387,8 @@ describe Mongoid::History do
         update_hash = {"tags_attributes" => { "1234" => { "id" => @tag_foo.id, "_destroy" => "1"} } }
         @post.update_attributes(update_hash)
 
-        #hisotrically this would have evaluated to 'Tags' and an error would be thrown
-        #on any call that walked up the association_chain, e.g. 'trackable'
+        # historically this would have evaluated to 'Tags' and an error would be thrown
+        # on any call that walked up the association_chain, e.g. 'trackable'
         @tag_foo.history_tracks.last.association_chain.last["name"].should == "tags"
         lambda{ @tag_foo.history_tracks.last.trackable }.should_not raise_error
       end


### PR DESCRIPTION
Currently there are cases (on destroy mianly) where an child document
would write it's class name to the association_hash 'name' field. This
happens  when it fails to lookup the relationship meta information pertaining to it's
parent OR when the child has been deleted off the parent record before
the destroy history track has been written.

Then if you are trying to use that history track later on, it would fail
the to be able to lookup it's trackable_parent, among other methods,
because it would try to traverse a relationship titled "Comment"
instead of the actual name of teh association, 'comments'.

This fix makes it so a child document doesn't fail to lookup the name of
the relation, when a parent is present, regardless of when the delete
occurs.
