### PR TITLE
Fix intermittent hash ordering issue with #history_tracks

### DIFF
--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -71,7 +71,7 @@ module Mongoid::History
 
     module MyInstanceMethods
       def history_tracks
-        @history_tracks ||= Mongoid::History.tracker_class.where(:scope => history_trackable_options[:scope], :association_chain => association_hash)
+        @history_tracks ||= Mongoid::History.tracker_class.where(:scope => history_trackable_options[:scope], :association_chain => { "$elemMatch" => association_hash })
       end
 
       #  undo :from => 1, :to => 5


### PR DESCRIPTION
The query generated by #history_tracks looks for an exact match in the association_chain array, including the order of the keys in the documents in the array. The hash order is indeterminate in Ruby 1.8 so sometimes the query works and sometimes it fails. Actually depending on the data in the database, it might find half the entries part of the time and other half the rest of the time. Using $elemMatch resolves the issue by making the query work regardless of the order of the keys in the database. Because the key order is indeterminate, I was unable to create a stable automated test.

This patch is made against the 2.4 branch. This fix should apply equally well to 0.3.0 because any app that used the earlier version will have mixed key orders in their database and they should be able to find them with 0.3.0 on 1.9.
