### PR TITLE
Specific before and after filters

### DIFF
--- a/lib/mongoid/history/tracker.rb
+++ b/lib/mongoid/history/tracker.rb
@@ -23,7 +23,6 @@ module Mongoid::History
           after_filter { |controller| Mongoid::History::Sweeper.instance.after(controller) }
         end
       end
-
     end
 
     def undo!(modifier)


### PR DESCRIPTION
When I was using mongoid-history with the mongoid hack for activeadmin I ran into a problem whereby the `around_filter` is invoked after the `before_create` filter for the history tracker document was called resulting in `nil` values for the `modifier` field in the history tracker.

I was able to solve this issue by adding explicit before and after filters. This pull request does not necessarily need to be merged into the master should the change cause other issues, however I was wondering if anyone had the same issue and whether or not anyone has any idea of why that is the case.

My suspicion is that it has something to do with the lack of `ActionController` filters in active admin. AA does implement the `around_filter` but doesn't invoke this filter at the same time as it is in `ActionController`, which results in the setting of the controller in the s`Sweper` after the user is asked for by the `before_create` filter resulting in `nil` values for the `modifier` field.

Any questions please let me know.
