### PR TITLE
Allow use with mongoid 3.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "easy_diff"
-gem "mongoid", "~> 3.0"
+gem "mongoid", ">= 3.0"
 gem "activesupport"
 
 group :test do


### PR DESCRIPTION
Mongoid 3.1.x has been around for almost a couple of months now, but mongoid-history only works with 3.0.x. This would allow use of mongoid-history with the newer versions of mongoid.
