### PR TITLE
solves default-scope issue and some methods

### DIFF
--- a/lib/mongoid/history/tracker.rb
+++ b/lib/mongoid/history/tracker.rb
@@ -189,12 +189,13 @@ module Mongoid::History
         name = node['name']
         doc = if doc.nil?
                 # root association. First element of the association chain
+                # unscoped is added to remove any default_scope defined in model
                 klass = name.classify.constantize
                 klass.unscoped.where(_id: node['id']).first
               elsif doc.class.embeds_one?(name)
                 doc.get_embedded(name)
               elsif doc.class.embeds_many?(name)
-                doc.get_embedded(name).where(_id: node['id']).first
+                doc.get_embedded(name).unscoped.where(_id: node['id']).first
               else
                 raise "This should never happen. Please report bug."
               end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -784,5 +784,96 @@ describe Mongoid::History do
         end
       end
     end
+
+    describe "when default scope is present" do
+      before do
+        class Post
+          default_scope where(title: nil)
+        end
+        class Comment
+          default_scope where(title: nil)
+        end
+        class User
+          default_scope where(name: nil)
+        end
+        class Tag
+          default_scope where(title: nil)
+        end
+      end
+
+      describe "post" do
+
+        it "should correctly undo and redo" do
+          post.update_attributes(:title => 'a new title')
+          track = post.history_tracks.last
+          track.undo! user
+          post.reload.title.should == 'Test'
+          track.redo! user
+          post.reload.title.should == 'a new title'
+        end
+
+        it "should stay the same after undo and redo" do
+          post.update_attributes(:title => 'testing')
+          track = post.history_tracks.last
+          track.undo! user
+          track.redo! user
+          post.reload.title.should == 'testing'
+        end
+      end
+      describe "comment" do
+        it "should correctly undo and redo" do
+          comment.update_attributes(:title => 'a new title')
+          track = comment.history_tracks.last
+          track.undo! user
+          comment.reload.title.should == 'test'
+          track.redo! user
+          comment.reload.title.should == 'a new title'
+        end
+
+        it "should stay the same after undo and redo" do
+          comment.update_attributes(:title => 'testing')
+          track = comment.history_tracks.last
+          track.undo! user
+          track.redo! user
+          comment.reload.title.should == 'testing'
+        end
+      end
+      describe "user" do
+        it "should correctly undo and redo" do
+          user.update_attributes(:name => 'a new name')
+          track = user.history_tracks.last
+          track.undo! user
+          user.reload.name.should == 'Aaron'
+          track.redo! user
+          user.reload.name.should == 'a new name'
+        end
+
+        it "should stay the same after undo and redo" do
+          user.update_attributes(:name => 'testing')
+          track = user.history_tracks.last
+          track.undo! user
+          track.redo! user
+          user.reload.name.should == 'testing'
+        end
+      end
+      describe "tag" do
+        it "should correctly undo and redo" do
+          tag.update_attributes(:title => 'a new title')
+          track = tag.history_tracks.last
+          track.undo! user
+          tag.reload.title.should == 'test'
+          track.redo! user
+          tag.reload.title.should == 'a new title'
+        end
+
+        it "should stay the same after undo and redo" do
+          tag.update_attributes(:title => 'testing')
+          track = tag.history_tracks.last
+          track.undo! user
+          track.redo! user
+          tag.reload.title.should == 'testing'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When a `default scope` is defined in a model and I was calling an `undo! @user` on an history-tracked object, I was getting the error: 
`NoMethodError: undefined method `history_trackable_options' for nil:NilClass`

I tracked this issue down to the `traverse_association_chain` method in history/tracker.rb, which is indirectly called in the `undo!` and `redo!` methods. I simply added an unscoped to remove the 'default scope' that was being applied and the error was no longer occurring. Even when there is no default scope defined, `unscoped` will still work and returns all the documents for that class without any filtering. 

What are your thoughts on this matter? 
