### PR TITLE
Add helper to track all embedded relations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ------------
 
 * [#170](https://github.com/mongoid/mongoid-history/pull/170): Parent repo is now [mongoid/mongoid-history](https://github.com/mongoid/mongoid-history) - [@dblock](https://github.com/dblock).
+* [#172](https://github.com/mongoid/mongoid-history/pull/172): Add config helper to track all embedded relations - [@jnfeinstein](https://github.com/jnfeinstein).
+
 * Your contribution here.
 
 0.6.0 (2016/09/13)

--- a/README.md
+++ b/README.md
@@ -156,6 +156,35 @@ Mongoid::History.disable do
 end
 ```
 
+You may want to track changes on all fields.
+
+```ruby
+class Post
+  include Mongoid::Document
+  include Mongoid::History::Trackable
+
+  field           :title
+  field           :body
+  field           :rating
+
+  track_history   :on => [:fields] # all fields will be tracked
+end
+```
+
+You can also track changes on all embedded relations.
+
+```ruby
+class Post
+  include Mongoid::Document
+  include Mongoid::History::Trackable
+
+  embeds_many :comments
+  embeds_one  :content
+
+  track_history   :on => [:embedded_relations] # all embedded relations will be tracked
+end
+```
+
 **Include embedded objects attributes in parent audit**
 
 Modify above `Post` and `Comment` classes as below:

--- a/lib/mongoid/history/options.rb
+++ b/lib/mongoid/history/options.rb
@@ -64,6 +64,11 @@ module Mongoid
           @options[:on] = options[:on] | trackable.fields.keys.map(&:to_sym) - reserved_fields.map(&:to_sym)
         end
 
+        if options[:on].include?(:embedded_relations)
+          @options[:on] = options[:on].reject { |opt| opt == :embedded_relations }
+          @options[:on] = options[:on] | trackable.embedded_relations.keys
+        end
+
         @options[:fields] = []
         @options[:dynamic] = []
         @options[:relations] = { embeds_one: {}, embeds_many: {} }

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -232,6 +232,16 @@ describe Mongoid::History::Options do
               let(:options) { { on: :my_field } }
               it { expect(subject[:dynamic]).to eq %w(my_field) }
             end
+
+            context 'with relations' do
+              let(:options) { { on: :embedded_relations } }
+              it do
+                expect(subject[:relations]).to eq(embeds_many: { 'emb_threes' => %w(_id f_em_foo fmb),
+                                                                 'emfs'       => %w(_id f_em_baz) },
+                                                  embeds_one: { 'emb_one'    => %w(_id f_em_foo fmb),
+                                                                'emtw'       => %w(_id f_em_baz) })
+              end
+            end
           end
         end
 


### PR DESCRIPTION
I think this was already in the works given the deprecation warning
when 'on' is set to 'all'.  Adding 'fields' already triggers on all
of the fields of the model, now adding 'relations' will do the same
for all embedded relations.  ['fields', 'relations'] should perform
the desired future behavior of 'all'.