### PR TITLE
Bump suggested rename method in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [#171](https://github.com/mongoid/mongoid-history/pull/171): Add field formatting - [@jnfeinstein](https://github.com/jnfeinstein).
 * [#172](https://github.com/mongoid/mongoid-history/pull/172): Add config helper to track all embedded relations - [@jnfeinstein](https://github.com/jnfeinstein).
 * [#173](https://github.com/mongoid/mongoid-history/pull/173): Compatible with mongoid 6 - [@sivagollapalli](https://github.com/sivagollapalli).
+* [#173](https://github.com/mongoid/mongoid-history/pull/173): Compatible with mongoid 6 - [@sivagollapalli](https://github.com/sivagollapalli).
+* [#179](https://github.com/mongoid/mongoid-history/pull/173): Improve suggested method for migrating from modified_id to userstamp fields in readme - [@colinxfleming](https://github.com/colinxfleming).
 
 0.6.0 (2016/09/13)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 * [#171](https://github.com/mongoid/mongoid-history/pull/171): Add field formatting - [@jnfeinstein](https://github.com/jnfeinstein).
 * [#172](https://github.com/mongoid/mongoid-history/pull/172): Add config helper to track all embedded relations - [@jnfeinstein](https://github.com/jnfeinstein).
 * [#173](https://github.com/mongoid/mongoid-history/pull/173): Compatible with mongoid 6 - [@sivagollapalli](https://github.com/sivagollapalli).
-* [#173](https://github.com/mongoid/mongoid-history/pull/173): Compatible with mongoid 6 - [@sivagollapalli](https://github.com/sivagollapalli).
-* [#179](https://github.com/mongoid/mongoid-history/pull/173): Improve suggested method for migrating from modified_id to userstamp fields in readme - [@colinxfleming](https://github.com/colinxfleming).
 
 0.6.0 (2016/09/13)
 ------------------

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Since October 2013 (mongoid-history version 0.4.1 and onwards), Mongoid::History
 instructions above then run the following command:
 
 ```
-MyHistoryTracker.all.each{|ht| ht.rename(:modifier_id, :created_by)
+MyHistoryTracker.all.rename(modifier_id: :created_by)
 ```
 
 **Setting Modifier Class Name**


### PR DESCRIPTION
Sorry for the tiny pull request -- was burying a body in an unrelated codebase and figured I'd try and do you all a solid while I was at it. 

This bumps the part of readme to reflect the new rename syntax in recent versions of mongoid (since 3 at least it looks like). Also contains an optimization by doing the operation on the collection level rather than the individual record level (though it'll work both ways) - saves a decent amount of time.

Doesn't affect any of the actual codebase or anything. Let me know if I can be of further assistance on this. 
