### PR TITLE
no-op on repeated calls to destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.6.1 (Next)
 
 * Your contribution here.
+* [#182](https://github.com/mongoid/mongoid-history/pull/182): No-op on repeated calls to destroy - [@msaffitz](https://github.com/msaffitz).
 * [#170](https://github.com/mongoid/mongoid-history/pull/170): Parent repo is now [mongoid/mongoid-history](https://github.com/mongoid/mongoid-history) - [@dblock](https://github.com/dblock).
 * [#171](https://github.com/mongoid/mongoid-history/pull/171): Add field formatting - [@jnfeinstein](https://github.com/jnfeinstein).
 * [#172](https://github.com/mongoid/mongoid-history/pull/172): Add config helper to track all embedded relations - [@jnfeinstein](https://github.com/jnfeinstein).

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -241,7 +241,7 @@ module Mongoid
         end
 
         def track_destroy
-          track_history_for_action(:destroy)
+          track_history_for_action(:destroy) unless destroyed?
         end
 
         def clear_trackable_memoization

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -136,6 +136,13 @@ describe Mongoid::History do
         post.destroy
         expect(post.history_tracks.last.affected['title']).to eq('Test')
       end
+
+      it 'should no-op on repeated calls to destroy' do
+        post.destroy
+        expect do
+          post.destroy
+        end.not_to change(Tracker, :count)
+      end
     end
 
     describe 'on update non-embedded' do


### PR DESCRIPTION
Calling `destroy` multiple times on the same document attempts to track each deletion, which ultimately fails with a RuntimeError when updating the (frozen) attributes hash with the incremented version number.  (This is especially problematic / difficult to track down for documents with cyclic relations and cascading destroys).

This no-ops tracking of destroy for documents that are already destroyed.