### PR TITLE
Fix bug when using multiple trackers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Your contribution here.
 
+* [#196](https://github.com/mongoid/mongoid-history/pull/196): Fix bug causing history tracks to get mixed up between multiple trackers when using multiple trackers - [@ojbucao](https://github.com/ojbucao).
+
 ### 0.6.1 (2017/01/04)
 
 * [#182](https://github.com/mongoid/mongoid-history/pull/182): No-op on repeated calls to destroy - [@msaffitz](https://github.com/msaffitz).

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ end
 
 group :development, :test do
   gem 'bundler'
+  gem 'pry'
   gem 'rake', '< 11.0'
 end
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ end
 **Set default tracker class name (Optional)**
 
 Mongoid::History will use the first loaded class to include Mongoid::History::Tracker as the
-default history tracker. If you are using multiple Tracker classes and would like to set
-a global default you may do so in a Rails initializer:
+default history tracker. If you are using multiple Tracker classes, you should set a global
+default in a Rails initializer:
 
 ```ruby
 # config/initializers/mongoid_history.rb
@@ -508,6 +508,46 @@ end
 ```
 
 For more examples, check out [spec/integration/integration_spec.rb](spec/integration/integration_spec.rb).
+
+** Multiple Trackers **
+
+You can have different trackers for different classes like so.
+
+```
+class First
+  include Mongoid::Document
+  include Mongoid::History::Trackable
+
+  field :text, type: String
+  track_history on: [:text],
+                tracker_class_name: :first_history_tracker
+end
+
+class Second
+  include Mongoid::Document
+  include Mongoid::History::Trackable
+
+  field :text, type: String
+  track_history on: [:text],
+                tracker_class_name: :second_history_tracker
+end
+
+class FirstHistoryTracker
+  include Mongoid::History::Tracker
+end
+
+class SecondHistoryTracker
+  include Mongoid::History::Tracker
+end
+```
+
+Note that if you are using a tracker for an embedded object that is different
+from the parent's tracker, redos and undos will not work. You have to use the
+same tracker for these to work across embedded relationships.
+
+If you are using multiple trackers and the `tracker_class_name` parameter is
+not specified, Mongoid::History will use the default tracker configured in the
+initializer file or whatever the first tracker was loaded.
 
 
 **Thread Safety**

--- a/lib/mongoid/history/tracker.rb
+++ b/lib/mongoid/history/tracker.rb
@@ -19,7 +19,7 @@ module Mongoid
         index(scope: 1)
         index(association_chain: 1)
 
-        Mongoid::History.tracker_class_name = name.tableize.singularize.to_sym
+        Mongoid::History.tracker_class_name ||= name.tableize.singularize.to_sym
       end
 
       def undo!(modifier = nil)

--- a/spec/integration/multiple_trackers_spec.rb
+++ b/spec/integration/multiple_trackers_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe Mongoid::History do
+  before :all do
+    Mongoid::History.tracker_class_name = nil
+
+    module MultipleTrackersSpec
+      class First
+        include Mongoid::Document
+        include Mongoid::History::Trackable
+
+        field :text, type: String
+        track_history on: [:text],
+                      track_create: true,
+                      track_update: true,
+                      track_destroy: true,
+                      tracker_class_name: :first_history_tracker
+      end
+
+      class Second
+        include Mongoid::Document
+        include Mongoid::History::Trackable
+
+        field :text, type: String
+        track_history on: [:text],
+                      track_create: true,
+                      track_update: true,
+                      track_destroy: true,
+                      tracker_class_name: :second_history_tracker
+      end
+    end
+
+    class FirstHistoryTracker
+      include Mongoid::History::Tracker
+    end
+
+    class SecondHistoryTracker
+      include Mongoid::History::Tracker
+    end
+  end
+
+  it 'should be possible to have different trackers for each class' do
+    expect(FirstHistoryTracker.count).to eq(0)
+    expect(SecondHistoryTracker.count).to eq(0)
+    expect(MultipleTrackersSpec::First.tracker_class).to be FirstHistoryTracker
+    expect(MultipleTrackersSpec::Second.tracker_class).to be SecondHistoryTracker
+
+    foo = MultipleTrackersSpec::First.new
+    foo.save
+
+    bar = MultipleTrackersSpec::Second.new
+    bar.save
+
+    expect(FirstHistoryTracker.count).to eq 1
+    expect(SecondHistoryTracker.count).to eq 1
+
+    foo.text = "I'm foo"
+    foo.save
+    bar.text = "I'm bar"
+    bar.save
+
+    expect(FirstHistoryTracker.count).to eq 2
+    expect(SecondHistoryTracker.count).to eq 2
+
+    foo.destroy
+    bar.destroy
+
+    expect(FirstHistoryTracker.count).to eq 3
+    expect(SecondHistoryTracker.count).to eq 3
+  end
+end


### PR DESCRIPTION
Problem: when using multiple trackers for different classes, the history gets mixed up between the different trackers.

Solution: remove the line on tracker.rb that sets the global history tracker everytime a tracker is loaded.