### PR TITLE
Dependency restrict validation failure spec

### DIFF
--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -287,7 +287,7 @@ module Mongoid
         end
 
         def untrack_history_for_action(action)
-          return unless track_history_for_action?(action) || @last_track.nil?
+          return unless track_history_for_action?(action) && !@last_track.nil?
           current_version = (send(history_trackable_options[:version_field]) || 0)
           send("#{history_trackable_options[:version_field]}=", current_version - 1)
           @last_track.destroy

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -24,7 +24,7 @@ module Mongoid
 
           before_update :track_update if options[:track_update]
           before_create :track_create if options[:track_create]
-          before_destroy :track_destroy if options[:track_destroy]
+          around_destroy :track_destroy if options[:track_destroy]
 
           Mongoid::History.trackable_class_options ||= {}
           Mongoid::History.trackable_class_options[options_parser.scope] = options
@@ -242,6 +242,14 @@ module Mongoid
 
         def track_destroy
           track_history_for_action(:destroy) unless destroyed?
+
+          begin
+            yield
+          rescue => e
+            untrack_history_for_action(:destroy)
+            @last_track = nil
+            raise e
+          end
         end
 
         def clear_trackable_memoization
@@ -273,9 +281,16 @@ module Mongoid
           if track_history_for_action?(action)
             current_version = (send(history_trackable_options[:version_field]) || 0) + 1
             send("#{history_trackable_options[:version_field]}=", current_version)
-            self.class.tracker_class.create!(history_tracker_attributes(action.to_sym).merge(version: current_version, action: action.to_s, trackable: self))
+            @last_track = self.class.tracker_class.create!(history_tracker_attributes(action.to_sym).merge(version: current_version, action: action.to_s, trackable: self))
           end
           clear_trackable_memoization
+        end
+
+        def untrack_history_for_action(action)
+          return unless track_history_for_action?(action) || @last_track.nil?
+          current_version = (send(history_trackable_options[:version_field]) || 0)
+          send("#{history_trackable_options[:version_field]}=", current_version - 1)
+          @last_track.destroy
         end
       end
 

--- a/spec/integration/subclasses_validation_spec.rb
+++ b/spec/integration/subclasses_validation_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Mongoid::History::Tracker do
+  before :all do
+    class Element
+      include Mongoid::Document
+      include Mongoid::Timestamps
+      include Mongoid::History::Trackable
+
+      field :title
+      field :body
+
+      validates :title, presence: true
+
+      has_many :items, dependent: :restrict
+
+      track_history on: [:body], track_create: true, track_update: true, track_destroy: true
+    end
+
+    class Item
+      include Mongoid::Document
+      include Mongoid::Timestamps
+
+      belongs_to :element
+    end
+
+    class Prompt < Element
+    end
+  end
+
+  it 'does not track delete when parent class validation fails' do
+    prompt = Prompt.new(title: 'first')
+    expect { prompt.save! }.to change(Tracker, :count).by(1)
+    expect do
+      expect { prompt.update_attributes!(title: nil, body: 'one') }
+        .to raise_error(Mongoid::Errors::Validations)
+    end.to change(Tracker, :count).by(0)
+  end
+
+  it 'does not track delete when restrict dependency fails' do
+    prompt = Prompt.new(title: 'first')
+    prompt.items << Item.new
+    expect { prompt.save! }.to change(Tracker, :count).by(1)
+    expect do
+      expect { prompt.destroy }.to raise_error(Mongoid::Errors::DeleteRestriction)
+    end.to change(Tracker, :count).by(0)
+  end
+end


### PR DESCRIPTION
This appears to be a bug. See details https://github.com/mongoid/mongoid-history/issues/200

This change results in a spec failure because a history record is created even though the destroy call raises an error:
```
  1) Mongoid::History::Tracker does not track delete when restrict dependency fails
     Failure/Error:
       expect do
         expect { prompt.destroy }.to raise_error(Mongoid::Errors::DeleteRestriction)
       end.to change(Tracker, :count).by(0)

       expected #count to have changed by 0, but was changed by 1
```