### PR TITLE
Do not create tracker on persistence error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Your contribution here.
 
+* [#202](https://github.com/mongoid/mongoid-history/pull/202): Do not create tracker on persistence error - [@mikwat](https://github.com/mikwat).
 * [#196](https://github.com/mongoid/mongoid-history/pull/196): Fix bug causing history tracks to get mixed up between multiple trackers when using multiple trackers - [@ojbucao](https://github.com/ojbucao).
 
 ### 0.6.1 (2017/01/04)

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ end
 
 For more examples, check out [spec/integration/integration_spec.rb](spec/integration/integration_spec.rb).
 
-** Multiple Trackers **
+**Multiple Trackers**
 
 You can have different trackers for different classes like so.
 
@@ -549,6 +549,17 @@ If you are using multiple trackers and the `tracker_class_name` parameter is
 not specified, Mongoid::History will use the default tracker configured in the
 initializer file or whatever the first tracker was loaded.
 
+
+**Dependent Restrict Associations**
+
+When `dependent: :restrict` is used on an association, a call to `destroy` on
+the model will raise `Mongoid::Errors::DeleteRestriction` when the dependency
+is violated. Just be aware that this gem will create a history track document
+before the `destroy` call and then remove if an error is raised. This applies
+to all persistence calls: create, update and destroy.
+
+See [spec/integration/validation_failure_spec.rb](spec/integration/validation_failure_spec.rb)
+for examples.
 
 **Thread Safety**
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,9 @@
+### Upgrading to 0.6.2
+
+#### Remove history track when create, update or destroy raises an error
+
+When an error is raised in a call to create, update or destroy a tracked model, any history track
+created before the call will now be deleted. In the past this was a problem for associations marked
+`dependent: :restrict`.
+
+See [#202](https://github.com/mongoid/mongoid-history/pull/202) for more information.

--- a/spec/integration/validation_failure_spec.rb
+++ b/spec/integration/validation_failure_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe Mongoid::History::Tracker do
+  before :all do
+    class Element
+      include Mongoid::Document
+      include Mongoid::Timestamps
+      include Mongoid::History::Trackable
+
+      field :title
+      field :body
+
+      validates :title, presence: true
+
+      has_many :items, dependent: :restrict
+
+      track_history on: [:body], track_create: true, track_update: true, track_destroy: true
+    end
+
+    class Item
+      include Mongoid::Document
+      include Mongoid::Timestamps
+
+      belongs_to :element
+    end
+
+    class Prompt < Element
+    end
+
+    @persisted_history_options = Mongoid::History.trackable_class_options
+  end
+
+  before(:each) { Mongoid::History.trackable_class_options = @persisted_history_options }
+
+  it 'does not track delete when parent class validation fails' do
+    prompt = Prompt.new(title: 'first')
+    expect { prompt.save! }.to change(Tracker, :count).by(1)
+    expect do
+      expect { prompt.update_attributes!(title: nil, body: 'one') }
+        .to raise_error(Mongoid::Errors::Validations)
+    end.to change(Tracker, :count).by(0)
+  end
+
+  it 'does not track delete when parent class restrict dependency fails' do
+    prompt = Prompt.new(title: 'first')
+    prompt.items << Item.new
+    expect { prompt.save! }.to change(Tracker, :count).by(1)
+    expect(prompt.version).to eq(1)
+    expect do
+      expect { prompt.destroy }.to raise_error(Mongoid::Errors::DeleteRestriction)
+    end.to change(Tracker, :count).by(0)
+  end
+
+  it 'does not track delete when restrict dependency fails' do
+    elem = Element.new(title: 'first')
+    elem.items << Item.new
+    expect { elem.save! }.to change(Tracker, :count).by(1)
+    expect(elem.version).to eq(1)
+    expect do
+      expect { elem.destroy }.to raise_error(Mongoid::Errors::DeleteRestriction)
+    end.to change(Tracker, :count).by(0)
+  end
+end

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -613,7 +613,7 @@ describe Mongoid::History::Trackable do
     let(:m) { MyModel.create!(foo: 'bar') }
 
     it 'should create history' do
-      expect { m.destroy! }.to change(Tracker, :count).by(1)
+      expect { m.destroy }.to change(Tracker, :count).by(1)
     end
 
     it 'should not create history when error raised' do

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -583,4 +583,63 @@ describe Mongoid::History::Trackable do
       Object.send(:remove_const, :MyTrackerClass)
     end
   end
+
+  describe '#track_update' do
+    before :all do
+      MyModel.track_history(on: :foo, track_update: true)
+      @persisted_history_options = Mongoid::History.trackable_class_options
+    end
+    before(:each) { Mongoid::History.trackable_class_options = @persisted_history_options }
+    let(:m) { MyModel.create!(foo: 'bar') }
+
+    it 'should create history' do
+      expect { m.update_attributes!(foo: 'bar2') }.to change(Tracker, :count).by(1)
+    end
+
+    it 'should not create history when error raised' do
+      expect(m).to receive(:update_attributes!).and_raise(StandardError)
+      expect do
+        expect { m.update_attributes!(foo: 'bar2') }.to raise_error(StandardError)
+      end.to change(Tracker, :count).by(0)
+    end
+  end
+
+  describe '#track_destroy' do
+    before :all do
+      MyModel.track_history(on: :foo, track_destroy: true)
+      @persisted_history_options = Mongoid::History.trackable_class_options
+    end
+    before(:each) { Mongoid::History.trackable_class_options = @persisted_history_options }
+    let(:m) { MyModel.create!(foo: 'bar') }
+
+    it 'should create history' do
+      expect { m.destroy! }.to change(Tracker, :count).by(1)
+    end
+
+    it 'should not create history when error raised' do
+      expect(m).to receive(:destroy!).and_raise(StandardError)
+      expect do
+        expect { m.destroy! }.to raise_error(StandardError)
+      end.to change(Tracker, :count).by(0)
+    end
+  end
+
+  describe '#track_create' do
+    before :all do
+      MyModel.track_history(on: :foo, track_create: true)
+      @persisted_history_options = Mongoid::History.trackable_class_options
+    end
+    before(:each) { Mongoid::History.trackable_class_options = @persisted_history_options }
+
+    it 'should create history' do
+      expect { MyModel.create!(foo: 'bar') }.to change(Tracker, :count).by(1)
+    end
+
+    it 'should not create history when error raised' do
+      expect(MyModel).to receive(:create!).and_raise(StandardError)
+      expect do
+        expect { MyModel.create!(foo: 'bar') }.to raise_error(StandardError)
+      end.to change(Tracker, :count).by(0)
+    end
+  end
 end

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -617,9 +617,9 @@ describe Mongoid::History::Trackable do
     end
 
     it 'should not create history when error raised' do
-      expect(m).to receive(:destroy!).and_raise(StandardError)
+      expect(m).to receive(:destroy).and_raise(StandardError)
       expect do
-        expect { m.destroy! }.to raise_error(StandardError)
+        expect { m.destroy }.to raise_error(StandardError)
       end.to change(Tracker, :count).by(0)
     end
   end


### PR DESCRIPTION
Here is a solution for the bug I reported in https://github.com/mongoid/mongoid-history/issues/200 The basic problem is that when a persistence method (`create!`, `update_attributes!`, `destroy!`) raises an error, the history tracker is still created since it happens in a `before_*` callback. This solution changes the approach to use `around_*` callbacks which cleanup on error.

I don't know if this is the best approach, but it appears to solve the bug and it doesn't break any tests. Feedback welcome.