### PR TITLE
Re-parse options at end of class definition

### DIFF
--- a/spec/integration/track_history_order_spec.rb
+++ b/spec/integration/track_history_order_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Mongoid::History::Tracker do
+  before :all do
+    class SpecModel
+      include Mongoid::Document
+      include Mongoid::History::Trackable
+
+      track_history on: :fields
+
+      field :foo
+    end
+  end
+
+  it 'should track all fields when field added after track_history' do
+    expect(SpecModel.tracked?(:foo)).to be true
+  end
+end

--- a/spec/unit/attributes/base_spec.rb
+++ b/spec/unit/attributes/base_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Mongoid::History::Attributes::Base do
   let(:model_one) do
-    Class.new do
+    klass = Class.new do
       include Mongoid::Document
       include Mongoid::History::Trackable
       field :foo
@@ -11,6 +11,8 @@ describe Mongoid::History::Attributes::Base do
         'ModelOne'
       end
     end
+    klass.end_tracepoint_reached = true
+    klass
   end
 
   before :all do

--- a/spec/unit/attributes/create_spec.rb
+++ b/spec/unit/attributes/create_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Mongoid::History::Attributes::Create do
   let(:model_one) do
-    Class.new do
+    klass = Class.new do
       include Mongoid::Document
       include Mongoid::History::Trackable
       store_in collection: :model_ones
@@ -12,6 +12,8 @@ describe Mongoid::History::Attributes::Create do
         'ModelOne'
       end
     end
+    klass.end_tracepoint_reached = true
+    klass
   end
 
   let(:obj_one) { model_one.new }

--- a/spec/unit/attributes/destroy_spec.rb
+++ b/spec/unit/attributes/destroy_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Mongoid::History::Attributes::Destroy do
   let(:model_one) do
-    Class.new do
+    klass = Class.new do
       include Mongoid::Document
       include Mongoid::History::Trackable
       store_in collection: :model_ones
@@ -12,6 +12,8 @@ describe Mongoid::History::Attributes::Destroy do
         'ModelOne'
       end
     end
+    klass.end_tracepoint_reached = true
+    klass
   end
 
   let(:obj_one) { model_one.new }

--- a/spec/unit/embedded_methods_spec.rb
+++ b/spec/unit/embedded_methods_spec.rb
@@ -4,7 +4,7 @@ describe Mongoid::History::Trackable do
   describe 'EmbeddedMethods' do
     describe 'embeds_one_class' do
       before :all do
-        ModelOne = Class.new do
+        class ModelOne
           include Mongoid::Document
           include Mongoid::History::Trackable
           embeds_one :emb_one, inverse_class_name: 'EmbOne'
@@ -12,12 +12,12 @@ describe Mongoid::History::Trackable do
           track_history
         end
 
-        EmbOne = Class.new do
+        class EmbOne
           include Mongoid::Document
           embedded_in :model_one
         end
 
-        EmbTwo = Class.new do
+        class EmbTwo
           include Mongoid::Document
           embedded_in :model_one
         end
@@ -36,7 +36,7 @@ describe Mongoid::History::Trackable do
 
     describe 'embeds_many_class' do
       before :all do
-        ModelOne = Class.new do
+        class ModelOne
           include Mongoid::Document
           include Mongoid::History::Trackable
           embeds_many :emb_ones, inverse_class_name: 'EmbOne'
@@ -44,12 +44,12 @@ describe Mongoid::History::Trackable do
           track_history
         end
 
-        EmbOne = Class.new do
+        class EmbOne
           include Mongoid::Document
           embedded_in :model_one
         end
 
-        EmbTwo = Class.new do
+        class EmbTwo
           include Mongoid::Document
           embedded_in :model_one
         end

--- a/spec/unit/my_instance_methods_spec.rb
+++ b/spec/unit/my_instance_methods_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Mongoid::History::Trackable do
   describe 'MyInstanceMethods' do
     before :all do
-      ModelOne = Class.new do
+      class ModelOne
         include Mongoid::Document
         include Mongoid::History::Trackable
         store_in collection: :model_ones
@@ -15,7 +15,7 @@ describe Mongoid::History::Trackable do
         embeds_many :emb_fours, store_as: :emfs, inverse_class_name: 'EmbFour'
       end
 
-      EmbOne = Class.new do
+      class EmbOne
         include Mongoid::Document
         include Mongoid::History::Trackable
         field :f_em_foo
@@ -23,14 +23,14 @@ describe Mongoid::History::Trackable do
         embedded_in :model_one
       end
 
-      EmbTwo = Class.new do
+      class EmbTwo
         include Mongoid::Document
         include Mongoid::History::Trackable
         field :baz
         embedded_in :model_one
       end
 
-      EmbThree = Class.new do
+      class EmbThree
         include Mongoid::Document
         include Mongoid::History::Trackable
         field :f_em_foo
@@ -38,7 +38,7 @@ describe Mongoid::History::Trackable do
         embedded_in :model_one
       end
 
-      EmbFour = Class.new do
+      class EmbFour
         include Mongoid::Document
         include Mongoid::History::Trackable
         field :baz
@@ -111,7 +111,7 @@ describe Mongoid::History::Trackable do
 
       describe 'embeds_one' do
         before(:all) do
-          Mail = Class.new do
+          class Mail
             include Mongoid::Document
             include Mongoid::History::Trackable
             store_in collection: :mails
@@ -119,7 +119,7 @@ describe Mongoid::History::Trackable do
             embeds_one :mail_subject, inverse_class_name: 'MailSubject'
           end
 
-          MailSubject = Class.new do
+          class MailSubject
             include Mongoid::Document
             field :content
             embedded_in :mail
@@ -164,14 +164,14 @@ describe Mongoid::History::Trackable do
 
       describe 'paranoia' do
         before(:all) do
-          ModelParanoia = Class.new do
+          class ModelParanoia
             include Mongoid::Document
             include Mongoid::History::Trackable
             store_in collection: :model_paranoias
             embeds_many :emb_para_ones, inverse_class_name: 'EmbParaOne'
           end
 
-          EmbParaOne = Class.new do
+          class EmbParaOne
             include Mongoid::Document
             field :em_foo
             field :deleted_at
@@ -287,7 +287,7 @@ describe Mongoid::History::Trackable do
 
       describe 'embeds_one' do
         before(:all) do
-          Email = Class.new do
+          class Email
             include Mongoid::Document
             include Mongoid::History::Trackable
             store_in collection: :emails
@@ -295,7 +295,7 @@ describe Mongoid::History::Trackable do
             embeds_one :email_subject, inverse_class_name: 'EmailSubject'
           end
 
-          EmailSubject = Class.new do
+          class EmailSubject
             include Mongoid::Document
             include Mongoid::History::Trackable
             field :content
@@ -346,14 +346,14 @@ describe Mongoid::History::Trackable do
         context 'when embeds_one has alias' do
           before(:all) do
             # Here i need class name constant in trackable.rb. So, not using `let` to define classes
-            ModelTwo = Class.new do
+            class ModelTwo
               include Mongoid::Document
               include Mongoid::History::Trackable
               store_in collection: :model_twos
               embeds_one :emb_two_one, inverse_class_name: 'EmbTwoOne'
             end
 
-            EmbTwoOne = Class.new do
+            class EmbTwoOne
               include Mongoid::Document
               include Mongoid::History::Trackable
               field :foo
@@ -388,14 +388,14 @@ describe Mongoid::History::Trackable do
         context 'when embeds_many has alias' do
           before(:all) do
             # Here i need class name constant in trackable.rb. So, not using `let` to define classes
-            ModelTwo = Class.new do
+            class ModelTwo
               include Mongoid::Document
               include Mongoid::History::Trackable
               store_in collection: :model_twos
               embeds_many :emb_two_ones, inverse_class_name: 'EmbTwoOne'
             end
 
-            EmbTwoOne = Class.new do
+            class EmbTwoOne
               include Mongoid::Document
               include Mongoid::History::Trackable
               field :foo

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Mongoid::History::Options do
   before :all do
-    ModelOne = Class.new do
+    class ModelOne
       include Mongoid::Document
       include Mongoid::History::Trackable
       store_in collection: :model_ones
@@ -15,27 +15,27 @@ describe Mongoid::History::Options do
       track_history
     end
 
-    EmbOne = Class.new do
+    class EmbOne
       include Mongoid::Document
       field :f_em_foo
       field :fmb, as: :f_em_bar
       embedded_in :model_one
     end
 
-    EmbTwo = Class.new do
+    class EmbTwo
       include Mongoid::Document
       field :f_em_baz
       embedded_in :model_one
     end
 
-    EmbThree = Class.new do
+    class EmbThree
       include Mongoid::Document
       field :f_em_foo
       field :fmb, as: :f_em_bar
       embedded_in :model_one
     end
 
-    EmbFour = Class.new do
+    class EmbFour
       include Mongoid::Document
       field :f_em_baz
       embedded_in :model_one

--- a/spec/unit/singleton_methods_spec.rb
+++ b/spec/unit/singleton_methods_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Mongoid::History::Trackable do
   describe 'SingletonMethods' do
     before :all do
-      MyTrackableModel = Class.new do
+      class MyTrackableModel
         include Mongoid::Document
         include Mongoid::History::Trackable
         field :foo
@@ -13,19 +13,19 @@ describe Mongoid::History::Trackable do
         embeds_many :my_embed_many_models, inverse_class_name: 'MyEmbedManyModel'
       end
 
-      MyEmbedOneModel = Class.new do
+      class MyEmbedOneModel
         include Mongoid::Document
         field :baz
         embedded_in :my_trackable_model
       end
 
-      MyUntrackedEmbedOneModel = Class.new do
+      class MyUntrackedEmbedOneModel
         include Mongoid::Document
         field :baz
         embedded_in :my_trackable_model
       end
 
-      MyEmbedManyModel = Class.new do
+      class MyEmbedManyModel
         include Mongoid::Document
         field :bla
         embedded_in :my_trackable_model
@@ -54,8 +54,8 @@ describe Mongoid::History::Trackable do
 
       context 'when dynamic enabled' do
         context 'with embeds one relation' do
-          let(:my_model) do
-            Class.new do
+          before(:all) do
+            class MyModel
               include Mongoid::Document
               include Mongoid::History::Trackable
               store_in collection: :my_models
@@ -65,28 +65,23 @@ describe Mongoid::History::Trackable do
           end
 
           it 'should track dynamic field' do
-            # Using `let` to define class and use that class inside `before` block to stub a method raises following error.
-            # RuntimeError:
-            #   let declaration `my_model` accessed in a `before(:context)` hook at:
-            #     /Users/vmc/projects/mongoid-history/spec/unit/singleton_methods_spec.rb:51:in `block (6 levels) in <top (required)>'
-            #
-            #   `let` and `subject` declarations are not intended to be called
-            #   in a `before(:context)` hook, as they exist to define state that
-            #   is reset between each example, while `before(:context)` exists to
-            #   define state that is shared across examples in an example group.
-            allow(my_model).to receive(:dynamic_enabled?) { true }
-            expect(my_model.dynamic_field?(:foo)).to be true
+            allow(MyModel).to receive(:dynamic_enabled?) { true }
+            expect(MyModel.dynamic_field?(:foo)).to be true
           end
 
           it 'should not track embeds_one relation' do
-            allow(my_model).to receive(:dynamic_enabled?) { true }
-            expect(my_model.dynamic_field?(:emb_one)).to be false
+            allow(MyModel).to receive(:dynamic_enabled?) { true }
+            expect(MyModel.dynamic_field?(:emb_one)).to be false
+          end
+
+          after(:all) do
+            Object.send(:remove_const, :MyModel)
           end
         end
 
         context 'with embeds one relation and alias' do
-          let(:my_model) do
-            Class.new do
+          before(:all) do
+            class MyModel
               include Mongoid::Document
               include Mongoid::History::Trackable
               store_in collection: :my_models
@@ -96,14 +91,18 @@ describe Mongoid::History::Trackable do
           end
 
           it 'should not track embeds_one relation' do
-            allow(my_model).to receive(:dynamic_enabled?) { true }
-            expect(my_model.dynamic_field?(:emo)).to be false
+            allow(MyModel).to receive(:dynamic_enabled?) { true }
+            expect(MyModel.dynamic_field?(:emo)).to be false
+          end
+
+          after(:all) do
+            Object.send(:remove_const, :MyModel)
           end
         end
 
         context 'with embeds many relation' do
-          let(:my_model) do
-            Class.new do
+          before(:all) do
+            class MyModel
               include Mongoid::Document
               include Mongoid::History::Trackable
               store_in collection: :my_models
@@ -113,14 +112,18 @@ describe Mongoid::History::Trackable do
           end
 
           it 'should not track embeds_many relation' do
-            allow(my_model).to receive(:dynamic_enabled?) { true }
-            expect(my_model.dynamic_field?(:emb_ones)).to be false
+            allow(MyModel).to receive(:dynamic_enabled?) { true }
+            expect(MyModel.dynamic_field?(:emb_ones)).to be false
+          end
+
+          after(:all) do
+            Object.send(:remove_const, :MyModel)
           end
         end
 
         context 'with embeds many relation and alias' do
-          let(:my_model) do
-            Class.new do
+          before(:all) do
+            class MyModel
               include Mongoid::Document
               include Mongoid::History::Trackable
               store_in collection: :my_models
@@ -130,8 +133,12 @@ describe Mongoid::History::Trackable do
           end
 
           it 'should not track embeds_many relation' do
-            allow(my_model).to receive(:dynamic_enabled?) { true }
-            expect(my_model.dynamic_field?(:emos)).to be false
+            allow(MyModel).to receive(:dynamic_enabled?) { true }
+            expect(MyModel.dynamic_field?(:emos)).to be false
+          end
+
+          after(:all) do
+            Object.send(:remove_const, :MyModel)
           end
         end
       end
@@ -168,7 +175,7 @@ describe Mongoid::History::Trackable do
 
     describe '#tracked_embeds_one_attributes' do
       before(:all) do
-        ModelOne = Class.new do
+        class ModelOne
           include Mongoid::Document
           include Mongoid::History::Trackable
           embeds_one :emb_one, inverse_class_name: 'EmbOne'
@@ -176,20 +183,20 @@ describe Mongoid::History::Trackable do
           embeds_one :emb_three, inverse_class_name: 'EmbThree'
         end
 
-        EmbOne = Class.new do
+        class EmbOne
           include Mongoid::Document
           field :em_foo
           field :em_bar
           embedded_in :model_one
         end
 
-        EmbTwo = Class.new do
+        class EmbTwo
           include Mongoid::Document
           field :em_bar
           embedded_in :model_one
         end
 
-        EmbThree = Class.new do
+        class EmbThree
           include Mongoid::Document
           field :em_baz
           embedded_in :model_one
@@ -237,7 +244,7 @@ describe Mongoid::History::Trackable do
 
     describe '#tracked_embeds_many_attributes' do
       before(:all) do
-        ModelOne = Class.new do
+        class ModelOne
           include Mongoid::Document
           include Mongoid::History::Trackable
           embeds_many :emb_ones, inverse_class_name: 'EmbOne'
@@ -245,20 +252,20 @@ describe Mongoid::History::Trackable do
           embeds_many :emb_threes, inverse_class_name: 'EmbThree'
         end
 
-        EmbOne = Class.new do
+        class EmbOne
           include Mongoid::Document
           field :em_foo
           field :em_bar
           embedded_in :model_one
         end
 
-        EmbTwo = Class.new do
+        class EmbTwo
           include Mongoid::Document
           field :em_bar
           embedded_in :model_one
         end
 
-        EmbThree = Class.new do
+        class EmbThree
           include Mongoid::Document
           field :em_baz
           embedded_in :model_one
@@ -295,8 +302,8 @@ describe Mongoid::History::Trackable do
     end
 
     describe '#trackable_scope' do
-      let(:model_one) do
-        Class.new do
+      before(:all) do
+        class ModelOne
           include Mongoid::Document
           include Mongoid::History::Trackable
           store_in collection: :model_ones
@@ -304,7 +311,11 @@ describe Mongoid::History::Trackable do
         end
       end
 
-      it { expect(model_one.trackable_scope).to eq(:model_one) }
+      it { expect(ModelOne.trackable_scope).to eq(:model_one) }
+
+      after(:all) do
+        Object.send(:remove_const, :ModelOne)
+      end
     end
 
     describe '#clear_trackable_memoization' do

--- a/spec/unit/tracker_spec.rb
+++ b/spec/unit/tracker_spec.rb
@@ -24,22 +24,18 @@ describe Mongoid::History::Tracker do
 
   describe '#tracked_edits' do
     before(:all) do
-      TrackerOne = Class.new do
-        def self.name
-          'TrackerOne'
-        end
-
+      class TrackerOne
         include Mongoid::History::Tracker
       end
 
-      ModelOne = Class.new do
+      class ModelOne
         include Mongoid::Document
         include Mongoid::History::Trackable
         store_in collection: :model_ones
         embeds_many :emb_ones, inverse_class_name: 'EmbOne'
       end
 
-      EmbOne = Class.new do
+      class EmbOne
         include Mongoid::Document
         field :em_foo
         embedded_in :model_one


### PR DESCRIPTION
Currently, `track_history` must be called after all of the fields/relations are defined because it memoizes them at the time of execution. This issue was described in https://github.com/mongoid/mongoid-history/issues/174.

This proposed fix adds a trace point that runs at end of the class definition and re-parses the options, picking up any fields/relations defined after the `track_history` call.

@dblock @jnfeinstein 