### PR TITLE
Skip yielding when no block provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#205](https://github.com/mongoid/mongoid-history/pull/205): Allow modifier field to be optional - [@yads](https://github.com/yads).
 * [#211](https://github.com/mongoid/mongoid-history/pull/211): Enable tracking create/destroy by default - [@jagdeepsingh](https://github.com/jagdeepsingh).
 * [#212](https://github.com/mongoid/mongoid-history/pull/212): `track_history` method support for `:if` and `:unless` options - [@jagdeepsingh](https://github.com/jagdeepsingh).
+* [#213](https://github.com/mongoid/mongoid-history/pull/213): Skip yielding when no block provided - [@mikwat](https://github.com/mikwat).
 * Your contribution here.
 
 ### 0.7.0 (2017/11/14)

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -273,7 +273,7 @@ module Mongoid
           track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?)
         end
 
-        def track_history_for_action(action)
+        def track_history_for_action(action, &block)
           if track_history_for_action?(action)
             current_version = (send(history_trackable_options[:version_field]) || 0) + 1
             send("#{history_trackable_options[:version_field]}=", current_version)
@@ -281,6 +281,8 @@ module Mongoid
           end
 
           clear_trackable_memoization
+
+          return unless block
 
           begin
             yield

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -273,7 +273,7 @@ module Mongoid
           track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?)
         end
 
-        def track_history_for_action(action, &block)
+        def track_history_for_action(action)
           if track_history_for_action?(action)
             current_version = (send(history_trackable_options[:version_field]) || 0) + 1
             send("#{history_trackable_options[:version_field]}=", current_version)
@@ -282,7 +282,7 @@ module Mongoid
 
           clear_trackable_memoization
 
-          return unless block
+          return unless block_given?
 
           begin
             yield

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -621,6 +621,19 @@ describe Mongoid::History::Trackable do
     end
   end
 
+  describe '#track_history_for_action' do
+    before(:all) { MyModel.track_history }
+    let!(:m) { MyModel.create!(foo: 'bar') }
+
+    it 'should yield block' do
+      expect { |b| m.send(:track_history_for_action, :update, &b) }.to yield_control
+    end
+
+    it 'should not raise error when no block' do
+      expect { m.send(:track_history_for_action, :update) }.not_to raise_error
+    end
+  end
+
   describe '#track_update' do
     before :all do
       MyModel.track_history(on: :foo, track_update: true)

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -623,7 +623,7 @@ describe Mongoid::History::Trackable do
 
   describe '#track_history_for_action' do
     before(:all) { MyModel.track_history }
-    let!(:m) { MyModel.create!(foo: 'bar') }
+    let(:m) { MyModel.create!(foo: 'bar') }
 
     it 'should yield block' do
       expect { |b| m.send(:track_history_for_action, :update, &b) }.to yield_control


### PR DESCRIPTION
Normally `track_history_for_action` is always called with a block via `around_create/update/destroy`, but I've found in my own code base that there are times when it's desirable to call this method directly without a block.

Regardless, this change seems like good hygiene with little downside. If a block isn't provided, then there's no need to rescue and rollback the new history track.