### PR TITLE
Solution for tracking has_and_belongs_to_many relations

### DIFF
--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -268,6 +268,12 @@ module Mongoid
           [original, modified]
         end
 
+        def increment_current_version
+          current_version = (send(history_trackable_options[:version_field]) || 0) + 1
+          send("#{history_trackable_options[:version_field]}=", current_version)
+          current_version
+        end
+
         protected
 
         def track_history_for_action?(action)
@@ -276,8 +282,7 @@ module Mongoid
 
         def track_history_for_action(action)
           if track_history_for_action?(action)
-            current_version = (send(history_trackable_options[:version_field]) || 0) + 1
-            send("#{history_trackable_options[:version_field]}=", current_version)
+            current_version = increment_current_version
             last_track = self.class.tracker_class.create!(history_tracker_attributes(action.to_sym).merge(version: current_version, action: action.to_s, trackable: self))
           end
 
@@ -297,6 +302,8 @@ module Mongoid
 
       module HasAndBelongsToManyMethods
         def track_has_and_belongs_to_many(related)
+          # skip for new records (track_create will capture assignment) and when track updates disabled
+          return true if new_record? || !track_history? || !history_trackable_options[:track_update]
           metadata = reflect_on_all_associations(:has_and_belongs_to_many).find { |m| m.class_name == related.class.name }
 
           related_id = related.id
@@ -310,26 +317,15 @@ module Mongoid
           modified = { metadata.key => modified_ids }
           original = { metadata.key => original_ids }
           action = :update
+          current_version = increment_current_version
           self.class.tracker_class.create!(
             history_tracker_attributes(action.to_sym)
-            .merge(version: increment_and_set_version,
+            .merge(version: current_version,
                    action: action.to_s,
                    original: original,
                    modified: modified,
                    trackable: self)
           )
-        end
-
-        private
-
-        def increment_and_set_version
-          if Mongoid::Compatibility::Version.mongoid3?
-            inc(:version, 1)
-          else
-            current_version = (version || 0) + 1
-            set(version: current_version)
-            current_version
-          end
         end
       end
 

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -19,6 +19,7 @@ module Mongoid
           end
 
           include MyInstanceMethods
+          include HasAndBelongsToManyMethods
           extend SingletonMethods
 
           delegate :history_trackable_options, to: 'self.class'
@@ -291,6 +292,35 @@ module Mongoid
             end
             raise e
           end
+        end
+      end
+
+      module HasAndBelongsToManyMethods
+        def track_has_and_belongs_to_many(related)
+          metadata = reflect_on_all_associations(:has_and_belongs_to_many).find { |m| m.class_name == related.class.name }
+
+          related_id = related.id
+          original_ids = send(metadata.key.to_sym)
+          modified_ids = if original_ids.include?(related_id)
+                           original_ids.reject { |id| id == related_id }
+                         else
+                           original_ids + [related_id]
+                         end
+          modified = { metadata.key => modified_ids }
+          original = { metadata.key => original_ids }
+
+          current_version = (version || 0) + 1
+          set(version: current_version)
+
+          action = :update
+          self.class.tracker_class.create!(
+            history_tracker_attributes(action.to_sym)
+            .merge(version: current_version,
+                   action: action.to_s,
+                   original: original,
+                   modified: modified,
+                   trackable: self)
+          )
         end
       end
 

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -306,21 +306,30 @@ module Mongoid
                          else
                            original_ids + [related_id]
                          end
+
           modified = { metadata.key => modified_ids }
           original = { metadata.key => original_ids }
-
-          current_version = (version || 0) + 1
-          set(version: current_version)
-
           action = :update
           self.class.tracker_class.create!(
             history_tracker_attributes(action.to_sym)
-            .merge(version: current_version,
+            .merge(version: increment_and_set_version,
                    action: action.to_s,
                    original: original,
                    modified: modified,
                    trackable: self)
           )
+        end
+
+        private
+
+        def increment_and_set_version
+          if Mongoid::Compatibility::Version.mongoid3?
+            inc(:version, 1)
+          else
+            current_version = (version || 0) + 1
+            set(version: current_version)
+            current_version
+          end
         end
       end
 

--- a/spec/integration/has_and_belongs_to_many_spec.rb
+++ b/spec/integration/has_and_belongs_to_many_spec.rb
@@ -9,8 +9,8 @@ describe Mongoid::History do
 
       field :title
       field :body
-      has_and_belongs_to_many :tags
-      track_history on: [:all], track_create: true, track_update: true
+      has_and_belongs_to_many :tags, before_add: :track_has_and_belongs_to_many, before_remove: :track_has_and_belongs_to_many
+      track_history on: %i[all], track_create: false, track_update: false
     end
 
     class Tag
@@ -19,45 +19,95 @@ describe Mongoid::History do
       field :title
       has_and_belongs_to_many :posts
     end
-
-    @persisted_history_options = Mongoid::History.trackable_class_options
   end
 
-  before(:each) { Mongoid::History.trackable_class_options = @persisted_history_options }
-  let(:tag) { Tag.create! }
-
   describe 'track' do
+    let(:tag) { Tag.create! }
+
     describe 'on creation' do
       let(:post) { Post.create!(tags: [tag]) }
+
+      it 'should create track' do
+        expect(post.history_tracks.count).to eq(1)
+      end
 
       it 'should assign tag_ids on modified' do
         expect(post.history_tracks.first.modified).to include('tag_ids' => [tag.id])
       end
 
-      it 'should not assign tag_ids on original' do
-        expect(post.history_tracks.first.original).to eq({})
+      it 'should assign empty tag_ids on original' do
+        expect(post.history_tracks.first.original).to include('tag_ids' => [])
       end
     end
 
-    describe 'on update' do
-      let(:post) { Post.create! }
-      before { post.tags = [tag] }
+    describe 'on add' do
+      let(:post) { Post.create!(tags: [tag]) }
+      let(:tag2) { Tag.create! }
+      before { post.tags << tag2 }
 
-      # TODO: remove, this just tests mongoid
+      # this just verifies that post is updated above
       it 'should update tags' do
-        expect(post.reload.tags).to eq([tag])
+        expect(post.reload.tags).to eq([tag, tag2])
+      end
+
+      it 'should create track' do
+        expect(post.history_tracks.count).to eq(2)
+      end
+
+      it 'should assign tag_ids on modified' do
+        expect(post.history_tracks.last.modified).to include('tag_ids' => [tag.id, tag2.id])
+      end
+
+      it 'should assign empty tag_ids on original' do
+        expect(post.history_tracks.last.original).to include('tag_ids' => [tag.id])
+      end
+    end
+
+    describe 'on remove' do
+      let(:post) { Post.create!(tags: [tag]) }
+      before { post.tags = [] }
+
+      # this just verifies that post is updated above
+      it 'should update tags' do
+        expect(post.reload.tags).to eq([])
       end
 
       it 'should create two tracks' do
         expect(post.history_tracks.count).to eq(2)
       end
 
-      it 'should assign tag_ids on modified' do
-        expect(post.history_tracks.last.modified).to include('tag_ids' => [tag.id])
+      it 'should assign empty tag_ids on modified' do
+        expect(post.history_tracks.last.modified).to include('tag_ids' => [])
       end
 
-      it 'should not assign tag_ids on original' do
-        expect(post.history_tracks.last.original).to eq({})
+      it 'should assign tag_ids on original' do
+        expect(post.history_tracks.last.original).to include('tag_ids' => [tag.id])
+      end
+    end
+
+    describe 'on reassign' do
+      let(:post) { Post.create!(tags: [tag]) }
+      let(:tag2) { Tag.create! }
+      before { post.tags = [tag2] }
+
+      # this just verifies that post is updated above
+      it 'should update tags' do
+        expect(post.reload.tags).to eq([tag2])
+      end
+
+      it 'should create three tracks' do
+        # 1. tags: [tag]
+        # 2. tags: []
+        # 3. tags: [tag2]
+        expect(post.history_tracks.count).to eq(3)
+      end
+
+      it 'should assign tag_ids on modified' do
+        expect(post.history_tracks.last.modified).to include('tag_ids' => [tag2.id])
+      end
+
+      it 'should assign empty tag_ids on original' do
+        expect(post.history_tracks.last.original).to include('tag_ids' => [])
       end
     end
   end

--- a/spec/integration/has_and_belongs_to_many_spec.rb
+++ b/spec/integration/has_and_belongs_to_many_spec.rb
@@ -2,17 +2,6 @@ require 'spec_helper'
 
 describe Mongoid::History do
   before :all do
-    class Post
-      include Mongoid::Document
-      include Mongoid::Timestamps
-      include Mongoid::History::Trackable
-
-      field :title
-      field :body
-      has_and_belongs_to_many :tags, before_add: :track_has_and_belongs_to_many, before_remove: :track_has_and_belongs_to_many
-      track_history on: %i[all], track_create: false, track_update: false
-    end
-
     class Tag
       include Mongoid::Document
 
@@ -22,6 +11,19 @@ describe Mongoid::History do
   end
 
   describe 'track' do
+    before :all do
+      class Post
+        include Mongoid::Document
+        include Mongoid::Timestamps
+        include Mongoid::History::Trackable
+
+        field :title
+        field :body
+        has_and_belongs_to_many :tags, before_add: :track_has_and_belongs_to_many, before_remove: :track_has_and_belongs_to_many
+        track_history on: %i[fields]
+      end
+    end
+
     let(:tag) { Tag.create! }
 
     describe 'on creation' do
@@ -35,8 +37,8 @@ describe Mongoid::History do
         expect(post.history_tracks.first.modified).to include('tag_ids' => [tag.id])
       end
 
-      it 'should assign empty tag_ids on original' do
-        expect(post.history_tracks.first.original).to include('tag_ids' => [])
+      it 'should be empty on original' do
+        expect(post.history_tracks.first.original).to eq({})
       end
     end
 
@@ -110,10 +112,67 @@ describe Mongoid::History do
         expect(post.history_tracks.last.original).to include('tag_ids' => [])
       end
     end
+
+    after :all do
+      Object.send(:remove_const, :Post)
+    end
+  end
+
+  describe 'not track' do
+    let!(:post) { Post.create! }
+
+    context 'track_update: false' do
+      before :all do
+        class Post
+          include Mongoid::Document
+          include Mongoid::Timestamps
+          include Mongoid::History::Trackable
+
+          field :title
+          field :body
+          has_and_belongs_to_many :tags, before_add: :track_has_and_belongs_to_many, before_remove: :track_has_and_belongs_to_many
+          track_history on: %i[fields], track_update: false
+        end
+      end
+
+      it 'should not create track' do
+        expect { post.tags = [Tag.create!] }.not_to change(Tracker, :count)
+      end
+
+      after :all do
+        Object.send(:remove_const, :Post)
+      end
+    end
+
+    context '#disable_tracking' do
+      before :all do
+        class Post
+          include Mongoid::Document
+          include Mongoid::Timestamps
+          include Mongoid::History::Trackable
+
+          field :title
+          field :body
+          has_and_belongs_to_many :tags, before_add: :track_has_and_belongs_to_many, before_remove: :track_has_and_belongs_to_many
+          track_history on: %i[fields]
+        end
+      end
+
+      it 'should not create track' do
+        expect do
+          Post.disable_tracking do
+            post.tags = [Tag.create!]
+          end
+        end.not_to change(Tracker, :count)
+      end
+
+      after :all do
+        Object.send(:remove_const, :Post)
+      end
+    end
   end
 
   after :all do
-    Object.send(:remove_const, :Post)
     Object.send(:remove_const, :Tag)
   end
 end

--- a/spec/integration/has_and_belongs_to_many_spec.rb
+++ b/spec/integration/has_and_belongs_to_many_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe Mongoid::History do
+  before :all do
+    class Post
+      include Mongoid::Document
+      include Mongoid::Timestamps
+      include Mongoid::History::Trackable
+
+      field :title
+      field :body
+      has_and_belongs_to_many :tags
+      track_history on: [:all], track_create: true, track_update: true
+    end
+
+    class Tag
+      include Mongoid::Document
+
+      field :title
+      has_and_belongs_to_many :posts
+    end
+
+    @persisted_history_options = Mongoid::History.trackable_class_options
+  end
+
+  before(:each) { Mongoid::History.trackable_class_options = @persisted_history_options }
+  let(:tag) { Tag.create! }
+
+  describe 'track' do
+    describe 'on creation' do
+      let(:post) { Post.create!(tags: [tag]) }
+
+      it 'should assign tag_ids on modified' do
+        expect(post.history_tracks.first.modified).to include('tag_ids' => [tag.id])
+      end
+
+      it 'should not assign tag_ids on original' do
+        expect(post.history_tracks.first.original).to eq({})
+      end
+    end
+
+    describe 'on update' do
+      let(:post) { Post.create! }
+      before { post.tags = [tag] }
+
+      # TODO: remove, this just tests mongoid
+      it 'should update tags' do
+        expect(post.reload.tags).to eq([tag])
+      end
+
+      it 'should create two tracks' do
+        expect(post.history_tracks.count).to eq(2)
+      end
+
+      it 'should assign tag_ids on modified' do
+        expect(post.history_tracks.last.modified).to include('tag_ids' => [tag.id])
+      end
+
+      it 'should not assign tag_ids on original' do
+        expect(post.history_tracks.last.original).to eq({})
+      end
+    end
+  end
+
+  after :all do
+    Object.send(:remove_const, :Post)
+    Object.send(:remove_const, :Tag)
+  end
+end

--- a/spec/integration/has_and_belongs_to_many_spec.rb
+++ b/spec/integration/has_and_belongs_to_many_spec.rb
@@ -58,7 +58,7 @@ describe Mongoid::History do
         expect(post.history_tracks.last.modified).to include('tag_ids' => [tag.id, tag2.id])
       end
 
-      it 'should assign empty tag_ids on original' do
+      it 'should assign tag_ids on original' do
         expect(post.history_tracks.last.original).to include('tag_ids' => [tag.id])
       end
     end


### PR DESCRIPTION
Currently, `has_and_belongs_to_many` relations are not tracked consistently. For example:

Given the following models:
```
class Post
  include Mongoid::Document
  include Mongoid::Timestamps
  include Mongoid::History::Trackable

  field :title
  field :body
  has_and_belongs_to_many :tags
  track_history on: %i[all], track_create: true, track_update: true
end

class Tag
  include Mongoid::Document

  field :title
  has_and_belongs_to_many :posts
end
```

Create with tags works as expected:
```
tag = Tag.create!
post = Post.create!(tags: [tag])
post.history_trackers.to_a
=> [#<Tracker _id: 5a579e2e017491024889a7b9, 
  created_at: 2018-01-11 17:26:06 UTC, 
  updated_at: 2018-01-11 17:26:06 UTC, 
  association_chain: [{"name"=>"Post", "id"=>BSON::ObjectId('5a579e2e017491024889a7b8')}], 
  modified: {"tag_ids"=>[BSON::ObjectId('5a579e2e017491024889a7b7')]}, 
  original: {}, 
  version: 1, 
  action: "create", 
  scope: "post", 
  modifier_id: nil>]
```

However, changes are not recorded:
```
tag = Tag.create!
tag2 = Tag.create!
post = Post.create!(tags: [tag])
post.tags << tag2
post.history_trackers.to_a
=> [#<Tracker _id: 5a579e2e017491024889a7b9, 
  created_at: 2018-01-11 17:26:06 UTC, 
  updated_at: 2018-01-11 17:26:06 UTC, 
  association_chain: [{"name"=>"Post", "id"=>BSON::ObjectId('5a579e2e017491024889a7b8')}], 
  modified: {"tag_ids"=>[BSON::ObjectId('5a579e2e017491024889a7b7')]}, 
  original: {}, 
  version: 1, 
  action: "create", 
  scope: "post", 
  modifier_id: nil>]
```

Unfortunately, none of the document callbacks (i.e. `around_update`, `around_create`, `around_destroy`) are called when modifications are made to a `has_and_belongs_to_many` relation. From my reading of the [Mongoid docs](https://docs.mongodb.com/mongoid/master/tutorials/mongoid-callbacks/#relation-callbacks) and code, the only way to be notified of changes to these relations is to attach a callback directly to the relation definition.

While inconvenient, this proposed solution simply makes a callback method available that must be attached to each `has_and_belongs_to_many` relation via `before_add: :track_has_and_belongs_to_many, before_remove: :track_has_and_belongs_to_many`. I don't know of a way to automatically attach these callbacks, but please educate me if this is possible.

Here's an example of this solution in use:
```
class Post
  include Mongoid::Document
  include Mongoid::Timestamps
  include Mongoid::History::Trackable

  field :title
  field :body
  has_and_belongs_to_many :tags, before_add: :track_has_and_belongs_to_many, before_remove: :track_has_and_belongs_to_many
  track_history on: %i[all], track_create: true, track_update: true
end

class Tag
  include Mongoid::Document

  field :title
  has_and_belongs_to_many :posts
end
```

```
tag = Tag.create!
tag2 = Tag.create!
post = Post.create!(tags: [tag])
post.tags << tag2
post.history_trackers.to_a
=> [
  #<Tracker _id: 5a57aa610174912e0c3edf88, 
    created_at: 2018-01-11 18:18:09 UTC, 
    updated_at: 2018-01-11 18:18:09 UTC, 
    association_chain: [{"name"=>"Post", "id"=>BSON::ObjectId('5a57aa610174912e0c3edf87')}], 
    modified: {"tag_ids"=>[BSON::ObjectId('5a57aa610174912e0c3edf85')]}, 
    original: {}, 
    version: 1, 
    action: "create", 
    scope: "post", 
    modifier_id: nil>, 
  #<Tracker _id: 5a57aa610174912e0c3edf89, 
    created_at: 2018-01-11 18:18:09 UTC, 
    updated_at: 2018-01-11 18:18:09 UTC, 
    association_chain: [{"name"=>"Post", "id"=>BSON::ObjectId('5a57aa610174912e0c3edf87')}], 
    modified: {"tag_ids"=>[BSON::ObjectId('5a57aa610174912e0c3edf85'), BSON::ObjectId('5a57aa610174912e0c3edf86')]}, 
    original: {"tag_ids"=>[BSON::ObjectId('5a57aa610174912e0c3edf85')]}, 
    version: 2, 
    action: "update", 
    scope: "post", 
    modifier_id: nil>
]
```