### PR TITLE
Fix tracking multiple embedded relations when used with tracked fields

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -45,7 +45,7 @@ Metrics/BlockLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 114
+  Max: 125
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.8.2 (Next)
 
+* [#233](https://github.com/mongoid/mongoid-history/pull/233): Bug fix-Track ALL embedded relations when used with fields and filtered attributes on embedded objects - [@jagdeepsingh](https://github.com/jagdeepsingh).
 * [#232](https://github.com/mongoid/mongoid-history/pull/232): Bug/187 track changes from embedded documents (not deeply nested) - [@Startouf](https://github.com/Startouf).
 * [#227](https://github.com/mongoid/mongoid-history/pull/227): Store options in inheritable class attributes - [@jnfeinstein](https://github.com/jnfeinstein).
 * [#229](https://github.com/mongoid/mongoid-history/pull/229), [#225](https://github.com/mongoid/mongoid-history/pull/225): Fixed inheritance of `history_trackable_options` - [@jnfeinstein](https://github.com/jnfeinstein).

--- a/lib/mongoid/history/options.rb
+++ b/lib/mongoid/history/options.rb
@@ -95,10 +95,18 @@ module Mongoid
         @options[:relations] = { embeds_one: {}, embeds_many: {} }
 
         options[:on].each do |option|
-          field = get_database_field_name(option)
-          field_options = get_field_options(option)
-          categorize_tracked_option(field, field_options)
+          if option.is_a?(Hash)
+            option.each { |k, v| split_and_categorize(k => v) }
+          else
+            split_and_categorize(option)
+          end
         end
+      end
+
+      def split_and_categorize(field_and_options)
+        field = get_database_field_name(field_and_options)
+        field_options = get_field_options(field_and_options)
+        categorize_tracked_option(field, field_options)
       end
 
       # Returns the database_field_name key for tracked option

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -275,6 +275,15 @@ describe Mongoid::History::Options do
               it { expect(subject[:relations][:embeds_many]).to eq('emb_threes' => %w[_id fmb]) }
             end
 
+            context 'with fields, and multiple embeds_one, and embeds_many relations' do
+              let(:options) { { on: [:foo, :bar, :emb_two, { emb_threes: %i[f_em_foo f_em_bar], emb_fours: :f_em_baz }] } }
+              it 'should categorize fields and associations correctly' do
+                expect(subject[:fields]).to eq(%w[foo b])
+                expect(subject[:relations][:embeds_one]).to eq('emtw' => %w[_id f_em_baz])
+                expect(subject[:relations][:embeds_many]).to eq('emb_threes' => %w[_id f_em_foo fmb], 'emfs' => %w[_id f_em_baz])
+              end
+            end
+
             context 'with field alias' do
               let(:options) { { on: :bar } }
               it { expect(subject[:fields]).to eq %w[b] }


### PR DESCRIPTION
This PR fixes a bug in current implementation of `mongoid-history` that when we use history tracking with fields as well as embedded relations with filtered attributes, it tracks only the first mentioned embedded relation.

Consider these models:

```ruby
class Car
  include Mongoid::Document
  include Mongoid::History::Trackable

  field :make, type: String
  field :name,  type: String
  
  embeds_one :steering_wheel
  embeds_many :seats

  track_history on: [:make, steering_wheel: :material, seats: [:is_leather, :whatever]]
end

class SteeringWheel
  include Mongoid::Document

  field :material, type: String
  field :shape,    type: Symbol

  embedded_in :car
end

class Seat
  include Mongoid::Document

  field :is_leather, type: Boolean
  field :whatever,  type: String

  embedded_in :car
end

Car.tracked_fields
=> ["make"]

Car.tracked_embeds_one
=> ["steering_wheel"]         # tracked because it was listed first in call to `track_history`

Car.tracked_embeds_one_attributes('steering_wheel')
=> ["_id", "material"]
```

## Expected Results

```ruby
Car.tracked_embeds_many
=> ["seats"]

Car.tracked_embeds_many_attributes('seats')
=> ["_id", "is_leather", "whatever"]
```

## Actual Results

```ruby
=> Car.tracked_embeds_many
[]

=> Car.tracked_embeds_many_attributes('seats')
nil
```