### PR TITLE
Fix Ruby 2.7 keyword argument warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.8.3 (Next)
 
 * Your contribution here.
+* [#236](https://github.com/mongoid/mongoid-history/pull/236): Fix Ruby 2.7 keyword argument warnings - [@vasilysn](https://github.com/vasilysn).
 
 ### 0.8.2 (2019/12/02)
 

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -25,9 +25,9 @@ module Mongoid
           delegate :track_history?, to: 'self.class'
 
           callback_options = history_options.options.slice(:if, :unless)
-          around_update :track_update, callback_options if history_options.options[:track_update]
-          around_create :track_create, callback_options if history_options.options[:track_create]
-          around_destroy :track_destroy, callback_options if history_options.options[:track_destroy]
+          around_update :track_update, **callback_options if history_options.options[:track_update]
+          around_create :track_create, **callback_options if history_options.options[:track_create]
+          around_destroy :track_destroy, **callback_options if history_options.options[:track_destroy]
 
           unless respond_to? :mongoid_history_options
             class_attribute :mongoid_history_options, instance_accessor: false


### PR DESCRIPTION
This PR fixes Ruby 2.7 keyword argument warnings.

```
./mongoid-history-0.8.2/lib/mongoid/history/trackable.rb:28: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
./activemodel-6.0.2.2/lib/active_model/callbacks.rb:138: warning: The called method is defined here
./mongoid-history-0.8.2/lib/mongoid/history/trackable.rb:29: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
./activemodel-6.0.2.2/lib/active_model/callbacks.rb:138: warning: The called method is defined here
./mongoid-history-0.8.2/lib/mongoid/history/trackable.rb:30: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
./activemodel-6.0.2.2/lib/active_model/callbacks.rb:138: warning: The called method is defined here
```