### PR TITLE
Improve `disable` and `disable_tracking`, add their inverses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#236](https://github.com/mongoid/mongoid-history/pull/236): Fix Ruby 2.7 keyword argument warnings - [@vasilysn](https://github.com/vasilysn).
 * [#237](https://github.com/mongoid/mongoid-history/pull/237): Fix tracking subclasses with additional fields - [@getaroom](https://github.com/getaroom).
 * [#239](https://github.com/mongoid/mongoid-history/pull/239): Optimize `modified_attributes_for_create` 6-7x - [@getaroom](https://github.com/getaroom).
+* [#240](https://github.com/mongoid/mongoid-history/pull/240): `Mongoid::History.disable` and `disable_tracking` now restore the original state if given a block and can be run without a block plus `Mongoid::History.enable` and `enable_tracking` have been added - [@getaroom](https://github.com/getaroom).
 
 ### 0.8.2 (2019/12/02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * [#236](https://github.com/mongoid/mongoid-history/pull/236): Fix Ruby 2.7 keyword argument warnings - [@vasilysn](https://github.com/vasilysn).
 * [#237](https://github.com/mongoid/mongoid-history/pull/237): Fix tracking subclasses with additional fields - [@getaroom](https://github.com/getaroom).
 * [#239](https://github.com/mongoid/mongoid-history/pull/239): Optimize `modified_attributes_for_create` 6-7x - [@getaroom](https://github.com/getaroom).
-* [#240](https://github.com/mongoid/mongoid-history/pull/240): `Mongoid::History.disable` and `disable_tracking` now restore the original state if given a block and can be run without a block plus `Mongoid::History.enable` and `enable_tracking` have been added - [@getaroom](https://github.com/getaroom).
+* [#240](https://github.com/mongoid/mongoid-history/pull/240): `Mongoid::History.disable` and `disable_tracking` now restore the original state - [@getaroom](https://github.com/getaroom).
+* [#240](https://github.com/mongoid/mongoid-history/pull/240): Added `Mongoid::History.enable`, `Mongoid::History.enable!`, `Mongoid::History.disable!`, `enable_tracking`, `enable_tracking!`, and `disable_tracking!` - [@getaroom](https://github.com/getaroom).
 
 ### 0.8.2 (2019/12/02)
 

--- a/README.md
+++ b/README.md
@@ -149,11 +149,34 @@ Comment.disable_tracking do
   comment.update_attributes(:title => "Test 3")
 end
 
-# globally disable all history tracking
+# disable tracking for comments by default
+Comment.disable_tracking
+
+# enable tracking for comments within a block
+Comment.enable_tracking do
+  comment.update_attributes(:title => "Test 3")
+end
+
+# renable tracking for comments by default
+Comment.enable_tracking
+
+# globally disable all history tracking within a block
 Mongoid::History.disable do
   comment.update_attributes(:title => "Test 3")
   user.update_attributes(:name => "Eddie Van Halen")
 end
+
+# globally disable all history tracking by default
+Mongoid::History.disable
+
+# globally enable all history tracking within a block
+Mongoid::History.enable do
+  comment.update_attributes(:title => "Test 3")
+  user.update_attributes(:name => "Eddie Van Halen")
+end
+
+# globally renable all history tracking by default
+Mongoid::History.enable
 ```
 
 You may want to track changes on all fields.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Comment.disable_tracking do
 end
 
 # disable tracking for comments by default
-Comment.disable_tracking
+Comment.disable_tracking!
 
 # enable tracking for comments within a block
 Comment.enable_tracking do
@@ -158,7 +158,7 @@ Comment.enable_tracking do
 end
 
 # renable tracking for comments by default
-Comment.enable_tracking
+Comment.enable_tracking!
 
 # globally disable all history tracking within a block
 Mongoid::History.disable do
@@ -167,7 +167,7 @@ Mongoid::History.disable do
 end
 
 # globally disable all history tracking by default
-Mongoid::History.disable
+Mongoid::History.disable!
 
 # globally enable all history tracking within a block
 Mongoid::History.enable do
@@ -176,7 +176,7 @@ Mongoid::History.enable do
 end
 
 # globally renable all history tracking by default
-Mongoid::History.enable
+Mongoid::History.enable!
 ```
 
 You may want to track changes on all fields.

--- a/lib/mongoid/history.rb
+++ b/lib/mongoid/history.rb
@@ -35,6 +35,9 @@ module Mongoid
         store[GLOBAL_TRACK_HISTORY_FLAG] = original_flag if block_given?
       end
 
+      alias disable! disable
+      alias enable! enable
+
       def enabled?
         store[GLOBAL_TRACK_HISTORY_FLAG] != false
       end

--- a/lib/mongoid/history.rb
+++ b/lib/mongoid/history.rb
@@ -19,11 +19,20 @@ module Mongoid
       attr_accessor :modifier_class_name
       attr_accessor :current_user_method
 
-      def disable(&_block)
-        store[GLOBAL_TRACK_HISTORY_FLAG] = false
-        yield
+      def disable(&block)
+        track(false, &block)
+      end
+
+      def enable(&block)
+        track(true, &block)
+      end
+
+      def track(state)
+        original_flag = store[GLOBAL_TRACK_HISTORY_FLAG]
+        store[GLOBAL_TRACK_HISTORY_FLAG] = state
+        yield if block_given?
       ensure
-        store[GLOBAL_TRACK_HISTORY_FLAG] = true
+        store[GLOBAL_TRACK_HISTORY_FLAG] = original_flag if block_given?
       end
 
       def enabled?

--- a/lib/mongoid/history.rb
+++ b/lib/mongoid/history.rb
@@ -19,17 +19,17 @@ module Mongoid
       attr_accessor :modifier_class_name
       attr_accessor :current_user_method
 
-      def disable(&block)
-        track(false, &block)
-      end
-
-      def enable(&block)
-        track(true, &block)
-      end
-
-      def track(state)
+      def disable
         original_flag = store[GLOBAL_TRACK_HISTORY_FLAG]
-        store[GLOBAL_TRACK_HISTORY_FLAG] = state
+        store[GLOBAL_TRACK_HISTORY_FLAG] = false
+        yield if block_given?
+      ensure
+        store[GLOBAL_TRACK_HISTORY_FLAG] = original_flag if block_given?
+      end
+
+      def enable
+        original_flag = store[GLOBAL_TRACK_HISTORY_FLAG]
+        store[GLOBAL_TRACK_HISTORY_FLAG] = true
         yield if block_given?
       ensure
         store[GLOBAL_TRACK_HISTORY_FLAG] = original_flag if block_given?

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -52,17 +52,17 @@ module Mongoid
           Mongoid::Compatibility::Version.mongoid3? || (self < Mongoid::Attributes::Dynamic).present?
         end
 
-        def disable_tracking(&block)
-          with_tracking(false, &block)
-        end
-
-        def enable_tracking(&block)
-          with_tracking(true, &block)
-        end
-
-        def with_tracking(state)
+        def disable_tracking
           original_flag = Mongoid::History.store[track_history_flag]
-          Mongoid::History.store[track_history_flag] = state
+          Mongoid::History.store[track_history_flag] = false
+          yield if block_given?
+        ensure
+          Mongoid::History.store[track_history_flag] = original_flag if block_given?
+        end
+
+        def enable_tracking
+          original_flag = Mongoid::History.store[track_history_flag]
+          Mongoid::History.store[track_history_flag] = true
           yield if block_given?
         ensure
           Mongoid::History.store[track_history_flag] = original_flag if block_given?

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -68,6 +68,9 @@ module Mongoid
           Mongoid::History.store[track_history_flag] = original_flag if block_given?
         end
 
+        alias disable_tracking! disable_tracking
+        alias enable_tracking! enable_tracking
+
         def track_history_flag
           "mongoid_history_#{name.underscore}_trackable_enabled".to_sym
         end

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -52,11 +52,20 @@ module Mongoid
           Mongoid::Compatibility::Version.mongoid3? || (self < Mongoid::Attributes::Dynamic).present?
         end
 
-        def disable_tracking(&_block)
-          Mongoid::History.store[track_history_flag] = false
-          yield
+        def disable_tracking(&block)
+          with_tracking(false, &block)
+        end
+
+        def enable_tracking(&block)
+          with_tracking(true, &block)
+        end
+
+        def with_tracking(state)
+          original_flag = Mongoid::History.store[track_history_flag]
+          Mongoid::History.store[track_history_flag] = state
+          yield if block_given?
         ensure
-          Mongoid::History.store[track_history_flag] = true
+          Mongoid::History.store[track_history_flag] = original_flag if block_given?
         end
 
         def track_history_flag

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -346,14 +346,14 @@ describe Mongoid::History::Trackable do
           end
 
           it 'should stay disabled if disable_tracking called without a block' do
-            MyModel.disable_tracking
+            MyModel.disable_tracking!
             expect(Mongoid::History.enabled?).to eq(true)
             expect(MyModel.new.track_history?).to eq(false)
           end
 
           it 'should stay enabled if enable_tracking called without a block' do
             MyModel.disable_tracking do
-              MyModel.enable_tracking
+              MyModel.enable_tracking!
               expect(Mongoid::History.enabled?).to eq(true)
               expect(MyModel.new.track_history?).to eq(true)
             end
@@ -461,14 +461,14 @@ describe Mongoid::History::Trackable do
           end
 
           it 'should stay disabled if disable called without a block' do
-            Mongoid::History.disable
+            Mongoid::History.disable!
             expect(Mongoid::History.enabled?).to eq(false)
             expect(MyModel.new.track_history?).to eq(false)
           end
 
           it 'should stay enabled if enable called without a block' do
             Mongoid::History.disable do
-              Mongoid::History.enable
+              Mongoid::History.enable!
               expect(Mongoid::History.enabled?).to eq(true)
               expect(MyModel.new.track_history?).to eq(true)
             end

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -270,6 +270,11 @@ describe Mongoid::History::Trackable do
 
     describe '#track_history?' do
       shared_examples_for 'history tracking' do
+        after do
+          Mongoid::History.store[Mongoid::History::GLOBAL_TRACK_HISTORY_FLAG] = true
+          Mongoid::History.store[MyModel.track_history_flag] = true
+        end
+
         context 'when tracking is globally enabled' do
           it 'should be enabled on the current thread' do
             expect(Mongoid::History.enabled?).to eq(true)
@@ -283,7 +288,40 @@ describe Mongoid::History::Trackable do
             end
           end
 
-          it 'should be rescued if an exception occurs' do
+          it 'should be enabled within enable_tracking' do
+            MyModel.disable_tracking do
+              MyModel.enable_tracking do
+                expect(Mongoid::History.enabled?).to eq(true)
+                expect(MyModel.new.track_history?).to eq(true)
+              end
+            end
+          end
+
+          it 'should still be disabled after completing a nested disable_tracking' do
+            MyModel.disable_tracking do
+              MyModel.disable_tracking {}
+              expect(Mongoid::History.enabled?).to eq(true)
+              expect(MyModel.new.track_history?).to eq(false)
+            end
+          end
+
+          it 'should still be enabled after completing a nested enable_tracking' do
+            MyModel.enable_tracking do
+              MyModel.enable_tracking {}
+              expect(Mongoid::History.enabled?).to eq(true)
+              expect(MyModel.new.track_history?).to eq(true)
+            end
+          end
+
+          it 'should restore the original state after completing enable_tracking' do
+            MyModel.disable_tracking do
+              MyModel.enable_tracking {}
+              expect(Mongoid::History.enabled?).to eq(true)
+              expect(MyModel.new.track_history?).to eq(false)
+            end
+          end
+
+          it 'should be rescued if an exception occurs in disable_tracking' do
             begin
               MyModel.disable_tracking do
                 raise 'exception'
@@ -292,6 +330,33 @@ describe Mongoid::History::Trackable do
             end
             expect(Mongoid::History.enabled?).to eq(true)
             expect(MyModel.new.track_history?).to eq(true)
+          end
+
+          it 'should be rescued if an exception occurs in enable_tracking' do
+            MyModel.disable_tracking do
+              begin
+                MyModel.enable_tracking do
+                  raise 'exception'
+                end
+              rescue
+              end
+              expect(Mongoid::History.enabled?).to eq(true)
+              expect(MyModel.new.track_history?).to eq(false)
+            end
+          end
+
+          it 'should stay disabled if disable_tracking called without a block' do
+            MyModel.disable_tracking
+            expect(Mongoid::History.enabled?).to eq(true)
+            expect(MyModel.new.track_history?).to eq(false)
+          end
+
+          it 'should stay enabled if enable_tracking called without a block' do
+            MyModel.disable_tracking do
+              MyModel.enable_tracking
+              expect(Mongoid::History.enabled?).to eq(true)
+              expect(MyModel.new.track_history?).to eq(true)
+            end
           end
 
           context 'with multiple classes' do
@@ -317,11 +382,46 @@ describe Mongoid::History::Trackable do
           end
         end
 
-        context 'when tracking is globally disabled' do
+        context 'when changing global tracking' do
           it 'should be disabled by the global disablement' do
             Mongoid::History.disable do
               expect(Mongoid::History.enabled?).to eq(false)
               expect(MyModel.new.track_history?).to eq(false)
+            end
+          end
+
+          it 'should be enabled by the global enablement' do
+            Mongoid::History.disable do
+              Mongoid::History.enable do
+                expect(Mongoid::History.enabled?).to eq(true)
+                expect(MyModel.new.track_history?).to eq(true)
+              end
+            end
+          end
+
+          it 'should restore the original state after completing enable' do
+            Mongoid::History.disable do
+              Mongoid::History.enable {}
+              expect(Mongoid::History.enabled?).to eq(false)
+              expect(MyModel.new.track_history?).to eq(false)
+            end
+          end
+
+          it 'should still be disabled after completing a nested disable' do
+            Mongoid::History.disable do
+              Mongoid::History.disable {}
+              expect(Mongoid::History.enabled?).to eq(false)
+              expect(MyModel.new.track_history?).to eq(false)
+            end
+          end
+
+          it 'should still be enabled after completing a nested enable' do
+            Mongoid::History.disable do
+              Mongoid::History.enable do
+                Mongoid::History.enable {}
+                expect(Mongoid::History.enabled?).to eq(true)
+                expect(MyModel.new.track_history?).to eq(true)
+              end
             end
           end
 
@@ -334,7 +434,7 @@ describe Mongoid::History::Trackable do
             end
           end
 
-          it 'should be rescued if an exception occurs' do
+          it 'should be rescued if an exception occurs in disable' do
             Mongoid::History.disable do
               begin
                 MyModel.disable_tracking do
@@ -344,6 +444,33 @@ describe Mongoid::History::Trackable do
               end
               expect(Mongoid::History.enabled?).to eq(false)
               expect(MyModel.new.track_history?).to eq(false)
+            end
+          end
+
+          it 'should be rescued if an exception occurs in enable' do
+            Mongoid::History.disable do
+              begin
+                Mongoid::History.enable do
+                  raise 'exception'
+                end
+              rescue
+              end
+              expect(Mongoid::History.enabled?).to eq(false)
+              expect(MyModel.new.track_history?).to eq(false)
+            end
+          end
+
+          it 'should stay disabled if disable called without a block' do
+            Mongoid::History.disable
+            expect(Mongoid::History.enabled?).to eq(false)
+            expect(MyModel.new.track_history?).to eq(false)
+          end
+
+          it 'should stay enabled if enable called without a block' do
+            Mongoid::History.disable do
+              Mongoid::History.enable
+              expect(Mongoid::History.enabled?).to eq(true)
+              expect(MyModel.new.track_history?).to eq(true)
             end
           end
 
@@ -361,7 +488,7 @@ describe Mongoid::History::Trackable do
               Object.send(:remove_const, :MyModel2)
             end
 
-            it 'should be disabled only for the class that calls disable_tracking' do
+            it 'should be disabled for all classes' do
               Mongoid::History.disable do
                 MyModel.disable_tracking do
                   expect(Mongoid::History.enabled?).to eq(false)


### PR DESCRIPTION
`Mongoid::History.disable` and `disable_tracking` now restore the
original state if given a block and can be run without a block plus
`Mongoid::History.enable` and `enable_tracking` have been added.

I was originally going to use these to globally disable tracking in our test suite and enable it selectively for individual tests, but we have request_store in our app and therefore the value got reset by individual requests. I ended up just stubbing `Mongoid::History.enabled?` instead.