### PR TITLE
Fixes for #244 and #245

### DIFF
--- a/lib/mongoid/history/attributes/update.rb
+++ b/lib/mongoid/history/attributes/update.rb
@@ -19,7 +19,6 @@ module Mongoid
 
         def changes_from_parent
           parent_changes = {}
-          puts changes.inspect.red
           changes.each do |k, v|
             change_value = begin
               if trackable_class.tracked_embeds_one?(k)

--- a/lib/mongoid/history/attributes/update.rb
+++ b/lib/mongoid/history/attributes/update.rb
@@ -19,6 +19,7 @@ module Mongoid
 
         def changes_from_parent
           parent_changes = {}
+          puts changes.inspect.red
           changes.each do |k, v|
             change_value = begin
               if trackable_class.tracked_embeds_one?(k)
@@ -90,8 +91,14 @@ module Mongoid
           relation = trackable_class.database_field_name(relation)
           relation_class = trackable_class.relation_class_of(relation)
           paranoia_field = Mongoid::History.trackable_class_settings(relation_class)[:paranoia_field]
-          original_value = value[0].reject { |rel| rel[paranoia_field].present? }
-                                   .map { |v_attrs| format_embeds_many_relation(relation, v_attrs) }
+
+          # DVB only process if the original value of the embedded relation is not nil
+          original_value = if value[0].present?
+            value[0].reject { |rel| rel[paranoia_field].present? }
+              .map { |v_attrs| format_embeds_many_relation(relation, v_attrs) }
+            else
+              nil
+            end
           modified_value = value[1].reject { |rel| rel[paranoia_field].present? }
                                    .map { |v_attrs| format_embeds_many_relation(relation, v_attrs) }
           return if original_value == modified_value

--- a/lib/mongoid/history/attributes/update.rb
+++ b/lib/mongoid/history/attributes/update.rb
@@ -90,14 +90,8 @@ module Mongoid
           relation = trackable_class.database_field_name(relation)
           relation_class = trackable_class.relation_class_of(relation)
           paranoia_field = Mongoid::History.trackable_class_settings(relation_class)[:paranoia_field]
-
-          # DVB only process if the original value of the embedded relation is not nil
-          original_value = if value[0].present?
-            value[0].reject { |rel| rel[paranoia_field].present? }
-              .map { |v_attrs| format_embeds_many_relation(relation, v_attrs) }
-            else
-              nil
-            end
+          original_value = (value[0] || []).reject { |rel| rel[paranoia_field].present? }
+                                   .map { |v_attrs| format_embeds_many_relation(relation, v_attrs) }
           modified_value = value[1].reject { |rel| rel[paranoia_field].present? }
                                    .map { |v_attrs| format_embeds_many_relation(relation, v_attrs) }
           return if original_value == modified_value

--- a/lib/mongoid/history/tracker.rb
+++ b/lib/mongoid/history/tracker.rb
@@ -95,7 +95,7 @@ module Mongoid
         @tracked_changes ||= (modified.keys | original.keys).inject(HashWithIndifferentAccess.new) do |h, k|
           h[k] = { from: original[k], to: modified[k] }.delete_if { |_, vv| vv.nil? }
           h
-        end.delete_if { |k, v| v.blank? || !trackable_parent_class.tracked?(k) }
+        end.delete_if { |k, v| v.blank? } #|| !trackable_parent_class.tracked?(k) }
       end
 
       # Outputs summary of edit actions performed: :add, :modify, :remove, or :array.


### PR DESCRIPTION
#244 - allow the tracker to track embedded relations

#245 - handle `nil` original value for an embeds_many relation