### PR TITLE
Avoid corrupt documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#239](https://github.com/mongoid/mongoid-history/pull/239): Optimize `modified_attributes_for_create` 6-7x - [@getaroom](https://github.com/getaroom).
 * [#240](https://github.com/mongoid/mongoid-history/pull/240): `Mongoid::History.disable` and `disable_tracking` now restore the original state - [@getaroom](https://github.com/getaroom).
 * [#240](https://github.com/mongoid/mongoid-history/pull/240): Added `Mongoid::History.enable`, `Mongoid::History.enable!`, `Mongoid::History.disable!`, `enable_tracking`, `enable_tracking!`, and `disable_tracking!` - [@getaroom](https://github.com/getaroom).
+* [](): Don't track changes on embedded documents if an ancestor is being destroyed in the same operation - [@getaroom](https://github.com/getaroom).
 
 ### 0.8.2 (2019/12/02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [#239](https://github.com/mongoid/mongoid-history/pull/239): Optimize `modified_attributes_for_create` 6-7x - [@getaroom](https://github.com/getaroom).
 * [#240](https://github.com/mongoid/mongoid-history/pull/240): `Mongoid::History.disable` and `disable_tracking` now restore the original state - [@getaroom](https://github.com/getaroom).
 * [#240](https://github.com/mongoid/mongoid-history/pull/240): Added `Mongoid::History.enable`, `Mongoid::History.enable!`, `Mongoid::History.disable!`, `enable_tracking`, `enable_tracking!`, and `disable_tracking!` - [@getaroom](https://github.com/getaroom).
-* [](): Don't track changes on embedded documents if an ancestor is being destroyed in the same operation - [@getaroom](https://github.com/getaroom).
+* [](): Don't update version on embedded documents if an ancestor is being destroyed in the same operation - [@getaroom](https://github.com/getaroom).
 
 ### 0.8.2 (2019/12/02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [#239](https://github.com/mongoid/mongoid-history/pull/239): Optimize `modified_attributes_for_create` 6-7x - [@getaroom](https://github.com/getaroom).
 * [#240](https://github.com/mongoid/mongoid-history/pull/240): `Mongoid::History.disable` and `disable_tracking` now restore the original state - [@getaroom](https://github.com/getaroom).
 * [#240](https://github.com/mongoid/mongoid-history/pull/240): Added `Mongoid::History.enable`, `Mongoid::History.enable!`, `Mongoid::History.disable!`, `enable_tracking`, `enable_tracking!`, and `disable_tracking!` - [@getaroom](https://github.com/getaroom).
-* [](): Don't update version on embedded documents if an ancestor is being destroyed in the same operation - [@getaroom](https://github.com/getaroom).
+* [#248](https://github.com/mongoid/mongoid-history/pull/248): Don't update version on embedded documents if an ancestor is being destroyed in the same operation - [@getaroom](https://github.com/getaroom).
 
 ### 0.8.2 (2019/12/02)
 

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -140,7 +140,7 @@ module Mongoid
         private
 
         def ancestor_flagged_for_destroy?(doc)
-          doc && doc.flagged_for_destroy? || ancestor_flagged_for_destroy?(doc._parent)
+          doc && (doc.flagged_for_destroy? || ancestor_flagged_for_destroy?(doc._parent))
         end
 
         def get_versions_criteria(options_or_version)
@@ -187,9 +187,7 @@ module Mongoid
         end
 
         def traverse_association_chain(node = self)
-          list = node._parent ? traverse_association_chain(node._parent) : []
-          list << association_hash(node)
-          list
+          (node._parent ? traverse_association_chain(node._parent) : []).tap { |list| list << association_hash(node) }
         end
 
         def association_hash(node = self)
@@ -273,10 +271,7 @@ module Mongoid
         end
 
         def clear_trackable_memoization
-          @history_tracker_attributes = nil
-          @modified_attributes_for_create = nil
-          @modified_attributes_for_update = nil
-          @history_tracks = nil
+          @history_tracker_attributes = @modified_attributes_for_create = @modified_attributes_for_update = @history_tracks = nil
         end
 
         # Transform hash of pair of changes into an `original` and `modified` hash

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -139,6 +139,10 @@ module Mongoid
 
         private
 
+        def ancestor_flagged_for_destroy?(doc)
+          doc && doc.flagged_for_destroy? || ancestor_flagged_for_destroy?(doc._parent)
+        end
+
         def get_versions_criteria(options_or_version)
           if options_or_version.is_a? Hash
             options = options_or_version
@@ -321,7 +325,7 @@ module Mongoid
         protected
 
         def track_history_for_action?(action)
-          track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?)
+          track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?) && !ancestor_flagged_for_destroy?(_parent)
         end
 
         def track_history_for_action(action)

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -320,12 +320,12 @@ module Mongoid
         protected
 
         def track_history_for_action?(action)
-          track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?) && !ancestor_flagged_for_destroy?(_parent)
+          track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?)
         end
 
         def track_history_for_action(action)
           if track_history_for_action?(action)
-            current_version = increment_current_version
+            current_version = ancestor_flagged_for_destroy?(_parent) ? send(history_trackable_options[:version_field]) : increment_current_version
             last_track = self.class.tracker_class.create!(
               history_tracker_attributes(action.to_sym)
               .merge(version: current_version, action: action.to_s, trackable: self)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,4 +27,6 @@ RSpec.configure do |config|
   config.before :each do
     Mongoid::History.reset!
   end
+
+  config.include ErrorHelpers
 end

--- a/spec/support/error_helpers.rb
+++ b/spec/support/error_helpers.rb
@@ -1,0 +1,7 @@
+module ErrorHelpers
+  def ignore_errors
+    yield
+  rescue StandardError => e
+    Mongoid.logger.debug "ignored error #{e}"
+  end
+end


### PR DESCRIPTION
When tracking history on deeply embedded documents where callbacks are cascaded from the root document, incrementing the version number of the embedded docs that are removed because an ancestor is removed causes conflicts in the atomic update, which are then written into an empty document in the 2nd pass, causing corrupt embedded documents to be persisted. Here we avoid updating the version of a document if an ancestor is being destroyed.