### PR TITLE
Avoid adding the version attribute to deleted docs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -31,7 +31,7 @@ Metrics/AbcSize:
 # Offense count: 122
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 837
+  Max: 900
 
 # Offense count: 1
 # Configuration parameters: CountComments.
@@ -56,7 +56,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 191
+  Max: 200
 
 # Offense count: 6
 Metrics/PerceivedComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.8.4 (Next)
 
+* [#249](https://github.com/mongoid/mongoid-history/pull/249): Don't update version on embedded documents if the document itself is being destroyed - [@getaroom](https://github.com/getaroom).
 * [#248](https://github.com/mongoid/mongoid-history/pull/248): Don't update version on embedded documents if an ancestor is being destroyed in the same operation - [@getaroom](https://github.com/getaroom).
 * Your contribution here.
 

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -325,9 +325,13 @@ module Mongoid
           track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?)
         end
 
+        def increment_current_version?(action)
+          action != :destroy && !ancestor_flagged_for_destroy?(_parent)
+        end
+
         def track_history_for_action(action)
           if track_history_for_action?(action)
-            current_version = ancestor_flagged_for_destroy?(_parent) ? next_version : increment_current_version
+            current_version = increment_current_version?(action) ? increment_current_version : next_version
             last_track = self.class.tracker_class.create!(
               history_tracker_attributes(action.to_sym)
               .merge(version: current_version, action: action.to_s, trackable: self)

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -509,8 +509,8 @@ describe Mongoid::History do
 
       it 'should be possible to destroy after re-create embedded from parent' do
         comment.destroy
-        post.history_tracks.last.undo!(user)
-        post.history_tracks.last.undo!(user)
+        post.history_tracks[-1].undo!(user)
+        post.history_tracks[-1].undo!(user)
         post.reload
         expect(post.comments.count).to eq(0)
       end


### PR DESCRIPTION
This is a follow up to [this PR](https://github.com/mongoid/mongoid-history/pull/248).

Adding the version attribute to a deleted embedded document is causing an update conflict, which mongoid ultimately applies after the removal of the document, creating an empty document with only the version attribute.

I had to relax a couple of the rubocop constraints in order to fit these changes in.

Also, there was another change in integration_spec.rb that appears unrelated. After making the change in trackable.rb, the specs started failing because, while the `history_tracks` method was returning a new array with an additional member, the `last` method was continuing to return the same record. Addressing the last member of the array by index avoids the issue.