### PR TITLE
256 track all blank changes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,7 +36,7 @@ Metrics/BlockLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 120
+  Max: 121
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
-### 0.9.1 (Next)
-
-* Your contribution here.
-
-### 0.9.0 (Unreleased)
+### 0.9.0 (Next)
 
 * [#257](https://github.com/mongoid/mongoid-history/pull/257): Add track_blank_changes option - [@BrianLMatthews](https://github.com/BrianLMatthews).
+* Your contribution here.
 
 ### 0.8.5 (2021/09/18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Your contribution here.
 
-### 0.9.0 (2024/08/07)
+### 0.9.0 (Unreleased)
 
 * [#257](https://github.com/mongoid/mongoid-history/pull/257): Add track_blank_changes option - [@BrianLMatthews](https://github.com/BrianLMatthews).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-### 0.8.7 (Next)
+### 0.9.1 (Next)
 
 * Your contribution here.
 
-### 0.8.6 (2024/08/07)
+### 0.9.0 (2024/08/07)
 
 * [#257](https://github.com/mongoid/mongoid-history/pull/257): Add track_blank_changes option - [@BrianLMatthews](https://github.com/BrianLMatthews).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-### 0.8.6 (Next)
+### 0.8.7 (Next)
 
 * Your contribution here.
+
+### 0.8.6 (2024/08/07)
+
+* [#257](https://github.com/mongoid/mongoid-history/pull/257): Add track_blank_changes option - [@BrianLMatthews](https://github.com/BrianLMatthews).
 
 ### 0.8.5 (2021/09/18)
 

--- a/Gemfile
+++ b/Gemfile
@@ -45,5 +45,6 @@ group :test do
   gem 'request_store'
   gem 'rspec', '~> 3.1'
   gem 'rubocop', '~> 0.49.0'
+  gem 'term-ansicolor', '~> 1.3.0'
   gem 'yard'
 end

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ class Post
                   :version_field => :version,   # adds "field :version, :type => Integer" to track current version, default is :version
                   :track_create  => true,       # track document creation, default is true
                   :track_update  => true,       # track document updates, default is true
-                  :track_destroy => true        # track document destruction, default is true
+                  :track_destroy => true,       # track document destruction, default is true
+                  :track_blank_changes => false # track changes from blank? to blank?, default is false
 end
 
 class Comment
@@ -282,6 +283,32 @@ end
 ```
 
 It will now track only `_id` (Mandatory), `title` and `content` attributes for `pages` relation.
+
+### Track all blank changes
+
+Normally changes where both the original and modified values respond with `true` to `blank?` (for example `nil` to `false`) aren't tracked. However, there may be cases where it's important to track such changes, for example when a field isn't present (so appears to be `nil`) then is set to `false`. To track such changes, set the `track_blank_changes` option to `true` (it defaults to `false`) when turning on history tracking:
+
+```ruby
+class Book
+  include Mongoid::Document
+  ...
+  field :summary
+  track_history # Use default of false for track_blank_changes
+end
+
+# summary change not tracked if summary hasn't been set (or has been set to something that responds true to blank?)
+Book.find(id).update_attributes(:summary => '')
+
+class Chapter
+  include Mongoid::Document
+  ...
+  field :title
+  track_history :track_blank_changes => true
+end
+
+# title change tracked even if title hasn't been set
+Chapter.find(id).update_attributes(:title => '')
+```
 
 ### Retrieving the list of tracked static and dynamic fields
 
@@ -604,6 +631,6 @@ You're encouraged to contribute to Mongoid History. See [CONTRIBUTING.md](CONTRI
 
 ## Copyright
 
-Copyright (c) 2011-2020 Aaron Qian and Contributors.
+Copyright (c) 2011-2024 Aaron Qian and Contributors.
 
 MIT License. See [LICENSE.txt](LICENSE.txt) for further details.

--- a/lib/mongoid/history/attributes/update.rb
+++ b/lib/mongoid/history/attributes/update.rb
@@ -18,6 +18,7 @@ module Mongoid
         private
 
         def changes_from_parent
+          track_blank_changes = trackable_class.history_trackable_options[:track_blank_changes]
           parent_changes = {}
           changes.each do |k, v|
             change_value = begin
@@ -26,7 +27,7 @@ module Mongoid
               elsif trackable_class.tracked_embeds_many?(k)
                 embeds_many_changes_from_parent(k, v)
               elsif trackable_class.tracked?(k, :update)
-                { k => format_field(k, v) } unless v.all?(&:blank?)
+                { k => format_field(k, v) } unless !track_blank_changes && v.all?(&:blank?)
               end
             end
             parent_changes.merge!(change_value) if change_value.present?

--- a/lib/mongoid/history/options.rb
+++ b/lib/mongoid/history/options.rb
@@ -34,6 +34,7 @@ module Mongoid
           track_create: true,
           track_update: true,
           track_destroy: true,
+          track_blank_changes: false,
           format: nil }
       end
 

--- a/lib/mongoid/history/version.rb
+++ b/lib/mongoid/history/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module History
-    VERSION = '0.8.5'.freeze
+    VERSION = '0.9.0'.freeze
   end
 end

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -356,6 +356,11 @@ describe Mongoid::History::Options do
           it { expect(subject[:track_destroy]).to be true }
         end
 
+        describe ':track_blank_changes' do
+          let(:options) { { track_blank_changes: true } }
+          it { expect(subject[:track_blank_changes]).to be true }
+        end
+
         describe '#remove_reserved_fields' do
           let(:options) { { on: %i[_id _type foo version modifier_id] } }
           it { expect(subject[:fields]).to eq %w[foo] }

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -103,6 +103,7 @@ describe Mongoid::History::Options do
           track_create: true,
           track_update: true,
           track_destroy: true,
+          track_blank_changes: false,
           format: nil
         }
       end
@@ -173,6 +174,7 @@ describe Mongoid::History::Options do
             track_create: true,
             track_update: true,
             track_destroy: true,
+            track_blank_changes: false,
             fields: %w[foo b],
             dynamic: [],
             relations: { embeds_one: {}, embeds_many: {} },

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -90,6 +90,7 @@ describe Mongoid::History::Trackable do
         track_create: true,
         track_update: true,
         track_destroy: true,
+        track_blank_changes: false,
         fields: %w[foo],
         relations: { embeds_one: {}, embeds_many: {} },
         dynamic: [],


### PR DESCRIPTION
Add the `track_blank_changes` option to track changes previously not tracked because both the original and modified values respond with `true` to `blank?`

Changes include adding the option, using the option when looping over `changes`, tests to test the above, documenting the option in `README.md`, and including the change in `CHANGELOG.md`.